### PR TITLE
Fix MacOS CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   test-container:
-    name: Test on fish ${{ matrix.fish_version }} on Docker
+    name: Test ${{ matrix.fish_version }} on Docker
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -17,7 +17,7 @@ jobs:
       - run: make test-pure-on FISH_VERSION=${{ matrix.fish_version }}
 
   test-macos:
-    name: Test on fish on MacOS
+    name: Test on MacOS
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
### What

Ensure the job for MacOS is running successfully.

### When?

Once `fishtape` is rewritten for `fish` `3.x`.