### PR TITLE
Refrain from printing container string matches

### DIFF
--- a/functions/_pure_prompt_container.fish
+++ b/functions/_pure_prompt_container.fish
@@ -1,5 +1,5 @@
 function _pure_prompt_container
-    if _pure_is_inside_container
+    if test -n _pure_is_inside_container
         echo "$pure_symbol_container_prefix"(_pure_user_at_host)
     end
 end

--- a/tests/_pure_prompt_container.test.fish
+++ b/tests/_pure_prompt_container.test.fish
@@ -12,7 +12,7 @@ function before_each
     _disable_colors
 end
 
-if test "$USER" = nemo
+if test "$USER" = nemo # we need to be in a container for those to work
     before_each
     @test "_pure_prompt_container: displays 'user@hostname' when inside container" (
         set --universal pure_enable_container_detection true


### PR DESCRIPTION
`_pure_is_inside_container` prints all matches. Using `test -n` will just evaluate to true/false depending on if matches found, which seems like the intention of this tests. This fixes #166 for me, but I'm not sure if it's the only fix required to close that issue.