### PR TITLE
Mark untracked as dirty; fix dirty marker when no HEAD ref

### DIFF
--- a/functions/_pure_prompt_git_dirty.fish
+++ b/functions/_pure_prompt_git_dirty.fish
@@ -7,6 +7,7 @@ function _pure_prompt_git_dirty
         # We put them in this order because checking staged changes is *fast*.
         not command git diff-index --ignore-submodules --cached --quiet HEAD -- >/dev/null 2>&1
         or not command git diff --ignore-submodules --no-ext-diff --quiet --exit-code >/dev/null 2>&1
+        or command git ls-files --others --exclude-standard --directory --no-empty-directory --error-unmatch -- ':/*' >/dev/null 2>&1
         and echo "true"
     )
     if test -n "$is_git_dirty"  # untracked or un-commited files

--- a/tests/_pure_prompt_git_dirty.test.fish
+++ b/tests/_pure_prompt_git_dirty.test.fish
@@ -21,7 +21,42 @@ function after_all
 end
 
 
-@test "_pure_prompt_git_dirty: untracked files make git repo as dirty" (
+@test "_pure_prompt_git_dirty: empty repo is not marked as dirty" (
+    set --universal pure_symbol_git_dirty '*'
+
+    _pure_prompt_git_dirty
+) = ''
+
+@test "_pure_prompt_git_dirty: untracked files in empty repo marked as dirty" (
+    touch file.txt
+    set --universal pure_symbol_git_dirty '*'
+
+    _pure_prompt_git_dirty
+) = '*'
+
+@test "_pure_prompt_git_dirty: staged files in empty repo marked as dirty" (
+    touch file.txt
+    git add file.txt
+    set --universal pure_symbol_git_dirty '*'
+
+    _pure_prompt_git_dirty
+) = '*'
+
+@test "_pure_prompt_git_dirty: clean is not marked as dirty" (
+    touch init.txt
+    git add init.txt
+    git commit --quiet --message 'initial commit'
+
+    set --universal pure_symbol_git_dirty '*'
+
+    _pure_prompt_git_dirty
+) = ''
+
+@test "_pure_prompt_git_dirty: untracked files mark git repo as dirty" (
+    touch init.txt
+    git add init.txt
+    git commit --quiet --message 'initial commit'
+
     touch file.txt
     set --universal pure_symbol_git_dirty '*'
 
@@ -29,6 +64,10 @@ end
 ) = '*'
 
 @test "_pure_prompt_git_dirty: staged files mark git repo as dirty" (
+    touch init.txt
+    git add init.txt
+    git commit --quiet --message 'initial commit'
+
     touch file.txt
     git add file.txt
     set --universal pure_symbol_git_dirty '*'

--- a/tests/_pure_prompt_git_dirty.test.fish
+++ b/tests/_pure_prompt_git_dirty.test.fish
@@ -29,23 +29,25 @@ end
 
 @test "_pure_prompt_git_dirty: untracked files in empty repo marked as dirty" (
     touch file.txt
+
     set --universal pure_symbol_git_dirty '*'
 
     _pure_prompt_git_dirty
 ) = '*'
 
 @test "_pure_prompt_git_dirty: staged files in empty repo marked as dirty" (
-    touch file.txt
+    echo "staged" >> file.txt
     git add file.txt
+
     set --universal pure_symbol_git_dirty '*'
 
     _pure_prompt_git_dirty
 ) = '*'
 
 @test "_pure_prompt_git_dirty: clean is not marked as dirty" (
-    touch init.txt
-    git add init.txt
-    git commit --quiet --message 'initial commit'
+    echo "clean" >> file.txt
+    git add file.txt
+    git commit --quiet --message 'commit staged files'
 
     set --universal pure_symbol_git_dirty '*'
 
@@ -53,30 +55,24 @@ end
 ) = ''
 
 @test "_pure_prompt_git_dirty: untracked files mark git repo as dirty" (
-    touch init.txt
-    git add init.txt
-    git commit --quiet --message 'initial commit'
+    touch file_2.txt
 
-    touch file.txt
     set --universal pure_symbol_git_dirty '*'
 
     _pure_prompt_git_dirty
 ) = '*'
 
 @test "_pure_prompt_git_dirty: staged files mark git repo as dirty" (
-    touch init.txt
-    git add init.txt
-    git commit --quiet --message 'initial commit'
+    echo "staged" >> file_2.txt
+    git add file_2.txt
 
-    touch file.txt
-    git add file.txt
     set --universal pure_symbol_git_dirty '*'
 
     _pure_prompt_git_dirty
 ) = '*'
 
 @test "_pure_prompt_git_dirty: symbol is colorized" (
-    touch file.txt
+    echo "colorized" >> file.txt
 
     source (dirname (status filename))/../functions/_pure_set_color.fish # enable colors
     set --universal pure_symbol_git_dirty '*'

--- a/tests/_pure_prompt_git_dirty.test.fish
+++ b/tests/_pure_prompt_git_dirty.test.fish
@@ -3,7 +3,7 @@ source (dirname (status filename))/../functions/_pure_prompt_git_dirty.fish
 @echo (_print_filename (status filename))
 
 
-function before_all
+function before_each
     mkdir -p /tmp/pure_pure_prompt_git_dirty # prevent conflict between parallel test files
     and cd /tmp/pure_pure_prompt_git_dirty
 
@@ -14,19 +14,21 @@ function before_all
     _purge_configs
     _disable_colors
 end
-before_all
 
-function after_all
+function after_each
     rm -rf /tmp/pure_pure_prompt_git_dirty
 end
 
 
+before_each
 @test "_pure_prompt_git_dirty: empty repo is not marked as dirty" (
     set --universal pure_symbol_git_dirty '*'
 
     _pure_prompt_git_dirty
 ) = ''
+after_each
 
+before_each
 @test "_pure_prompt_git_dirty: untracked files in empty repo marked as dirty" (
     touch file.txt
 
@@ -34,7 +36,9 @@ end
 
     _pure_prompt_git_dirty
 ) = '*'
+after_each
 
+before_each
 @test "_pure_prompt_git_dirty: staged files in empty repo marked as dirty" (
     echo "staged" >> file.txt
     git add file.txt
@@ -43,7 +47,9 @@ end
 
     _pure_prompt_git_dirty
 ) = '*'
+after_each
 
+before_each
 @test "_pure_prompt_git_dirty: clean is not marked as dirty" (
     echo "clean" >> file.txt
     git add file.txt
@@ -53,7 +59,9 @@ end
 
     _pure_prompt_git_dirty
 ) = ''
+after_each
 
+before_each
 @test "_pure_prompt_git_dirty: untracked files mark git repo as dirty" (
     touch file_2.txt
 
@@ -61,7 +69,9 @@ end
 
     _pure_prompt_git_dirty
 ) = '*'
+after_each
 
+before_each
 @test "_pure_prompt_git_dirty: staged files mark git repo as dirty" (
     echo "staged" >> file_2.txt
     git add file_2.txt
@@ -70,7 +80,9 @@ end
 
     _pure_prompt_git_dirty
 ) = '*'
+after_each
 
+before_each
 @test "_pure_prompt_git_dirty: symbol is colorized" (
     echo "colorized" >> file.txt
 
@@ -80,6 +92,4 @@ end
 
     _pure_prompt_git_dirty
 ) = (set_color brblack)'*'
-
-
-after_all
+after_each


### PR DESCRIPTION
Summary of changes:

- Add the dirty marker when untracked files are present
- Fix behaviour of dirty marker when there is no `HEAD`
- Test `_pure_prompt_git_dirty` when `HEAD` does and does not exist

Currently, `_pure_prompt_git_dirty` does not add the dirty maker for untracked files. The implementation here is [as it's done in ` git/contrib/completion/git-prompt.sh`](https://github.com/git/git/blob/e5a14ddd2d93da4d951fd63d4f78fe2410debe68/contrib/completion/git-prompt.sh#L541).

When I went to go add a test for this feature, I discovered it was [already there](https://github.com/pure-fish/pure/blob/c0df5cb4726aa6831c0473556066a4cbf48fc79e/tests/_pure_prompt_git_dirty.test.fish#L23) - and passing! This is because the [`git diff-index [...] HEAD --` used](https://github.com/pure-fish/pure/blob/c0df5cb4726aa6831c0473556066a4cbf48fc79e/functions/_pure_prompt_git_dirty.fish#L8) gives a non-zero exit code when `HEAD` is not present. All repos without a `HEAD` are therefore marked as dirty. During testing, the repo does not have a `HEAD`.

This PR fixes that, falling back to a `git diff --staged` when `HEAD` is not present. It also ~duplicates the existing tests to check the dirty marker works as expected immediately after `git init` (i.e. no `HEAD`) and after an initial commit (i.e. with a `HEAD`).

To (maybe) clarify things a bit: with the tests in this PR, both `_pure_prompt_git_dirty: empty repo is not marked as dirty` and `_pure_prompt_git_dirty: untracked files mark git repo as dirty` fail on `master`.

Wasn't sure if this should be behind a new feature flag (e.g. `pure_untracked_is_dirty`). It is documented/expected behaviour, but this fix might slow down the prompt in large repos (c.f. #189). FWIW I did a quick check with the full [cpython source](https://github.com/python/cpython) and _on my machine_ the time is comparable to the existing commands,

```console
spthm@local:~/cpython main $ touch file.txt
spthm@local:~/cpython main $ time git ls-files --others --exclude-standard --directory --no-empty-directory --error-unmatch -- ':/*'
file.txt
git ls-files --others --exclude-standard --directory --no-empty-directory  --  0.02s user 0.03s system 84% cpu 0.052 total
spthm@local:~/cpython main $ time git diff-index --ignore-submodules --cached --quiet HEAD -- >/dev/null 2>&1 
git diff-index --ignore-submodules --cached --quiet HEAD -- > /dev/null 2>&1  0.01s user 0.02s system 54% cpu 0.055 total
```