### PR TITLE
Update fisher installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ### [Fisher](https://github.com/jorgebucaran/fisher)
 
 ```fish
-fisher install pure-fish/pure
+fisher add pure-fish/pure
 ```
 
 ### Manually


### PR DESCRIPTION
I have fisher version 3.1.1 and  the`install` command didn't worked for me. `fisher add` did