### PR TITLE
container check: support other container runtimes

### DIFF
--- a/functions/_pure_is_inside_container.fish
+++ b/functions/_pure_is_inside_container.fish
@@ -10,5 +10,5 @@ function _pure_is_inside_container \
                 --regex '(lxc|docker)' \
             <$cgroup_namespace
     end
-    or test "$container" = "lxc"
+    or test -n "$container"
 end


### PR DESCRIPTION
Check if the $container environment variable is set to detect if we are in a container. This allow the prompt to support other container runtimes.