### PR TITLE
move space in prompt causing bad formatting in single line mode

### DIFF
--- a/functions/_pure_prompt.fish
+++ b/functions/_pure_prompt.fish
@@ -15,13 +15,13 @@ function _pure_prompt \
     end
 
     echo (\
-            _pure_print_prompt \
-                $system_time \
-                $root_prefix \
-                $jobs \
-                $virtualenv \
-                $vimode_indicator \
-                $space \
-                $pure_symbol \
+        _pure_print_prompt \
+        $space \
+        $system_time \
+        $root_prefix \
+        $jobs \
+        $virtualenv \
+        $vimode_indicator \
+        $pure_symbol \
     )
 end


### PR DESCRIPTION
fixes: #276

Can't rebase #285, so I'm duplicating here (cc @speyejack)
> By moving the space to the beginning, it fixes the virtualenv from
being badly formatted with first prompt line.
