### PR TITLE
fix/macos container detection

### DIFF
--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --global pure_version 4.2.0 # For bug report and tag-after-merge workflow
+set --global pure_version 4.2.1 # For bug report and tag-after-merge workflow
 
 # Base colors
 _pure_set_default pure_color_primary blue

--- a/functions/_pure_detect_container_by_pid_method.fish
+++ b/functions/_pure_detect_container_by_pid_method.fish
@@ -3,9 +3,15 @@ function _pure_detect_container_by_pid_method \
 
     set --query proc_sched[1]; or set proc_sched /proc/1/sched
 
-    head -n 1 $proc_sched \
-        | string match \
-        --quiet \
-        --invert \
-        --regex 'init|systemd'
+    set --local os_name (uname -s)
+    if test $os_name != "Darwin"
+        head -n 1 $proc_sched \
+            | string match \
+            --quiet \
+            --invert \
+            --regex 'init|systemd'
+    else
+        set --local failure 1
+        return $failure
+    end
 end

--- a/functions/_pure_is_inside_container.fish
+++ b/functions/_pure_is_inside_container.fish
@@ -7,8 +7,11 @@ function _pure_is_inside_container \
         return $success
     end
 
-    if _pure_detect_container_by_pid_method
-        return $success
+    set --local os_name (uname -s)
+    if test $os_name != "Darwin"
+        if _pure_detect_container_by_pid_method
+            return $success
+        end
     end
 
     if _pure_detect_container_by_cgroup_method $cgroup_namespace

--- a/functions/_pure_is_inside_container.fish
+++ b/functions/_pure_is_inside_container.fish
@@ -7,11 +7,8 @@ function _pure_is_inside_container \
         return $success
     end
 
-    set --local os_name (uname -s)
-    if test $os_name != "Darwin"
-        if _pure_detect_container_by_pid_method
-            return $success
-        end
+    if _pure_detect_container_by_pid_method
+        return $success
     end
 
     if _pure_detect_container_by_cgroup_method $cgroup_namespace

--- a/functions/_pure_is_inside_container.fish
+++ b/functions/_pure_is_inside_container.fish
@@ -2,14 +2,6 @@ function _pure_is_inside_container \
     --argument-names cgroup_namespace
     set --query cgroup_namespace[1]; or set cgroup_namespace /proc/1/cgroup
 
-    function _pure_detect_container_by_pid_method # see https://stackoverflow.com/a/37015387/802365
-        head -n 1 /proc/1/sched \
-            | string match \
-            --quiet \
-            --invert \
-            --regex 'init|systemd'
-    end
-
     set --local success 0
     if test -n "$container"
         return $success

--- a/tests/_pure_detect_container_by_pid_method.test.fish
+++ b/tests/_pure_detect_container_by_pid_method.test.fish
@@ -9,6 +9,10 @@ function setup
 end
 setup
 
+function teardown
+    functions --erase  uname
+end
+
 @test "_pure_detect_container_by_pid_method: true for init" (
     set --local proc_sched /proc/1/sched
     echo "init (1, #threads: 1)" >$proc_sched
@@ -23,16 +27,17 @@ setup
     _pure_detect_container_by_pid_method $proc_sched
 ) $status -eq $SUCCESS
 
-# @test "_pure_detect_container_by_pid_method: true for MacOS" (
-#     set --local proc_sched /proc/1/sched
-#     echo "launchd (1, #threads: 1)" >$proc_sched
-
-#     _pure_detect_container_by_pid_method $proc_sched
-# ) $status -eq $SUCCESS
-
 @test "_pure_detect_container_by_pid_method: true for Github Action" (
     set --local proc_sched /proc/1/sched
     echo "systemd (1, #threads: 1)" >$proc_sched
 
     _pure_detect_container_by_pid_method $proc_sched
 ) $status -eq $SUCCESS
+
+@test "_pure_detect_container_by_pid_method: skip pid method on MacOS" (
+    function uname; echo "Darwin"; end # mock
+
+    _pure_detect_container_by_pid_method
+) $status -eq $FAILURE
+
+teardown

--- a/tests/_pure_is_inside_container.test.fish
+++ b/tests/_pure_is_inside_container.test.fish
@@ -1,5 +1,7 @@
 source (dirname (status filename))/fixtures/constants.fish
 source (dirname (status filename))/../functions/_pure_is_inside_container.fish
+source (dirname (status filename))/../functions/_pure_detect_container_by_pid_method.fish
+source (dirname (status filename))/../functions/_pure_detect_container_by_cgroup_method.fish
 @echo (_print_filename (status filename))
 
 
@@ -22,9 +24,22 @@ function teardown
     set --erase namespace
 end
 
-@test "_pure_is_inside_container: true for Github Action" ( # docker >=v20?
+@test "_pure_is_inside_container: true for Github Action" (
     _pure_is_inside_container
 ) $status -eq $SUCCESS
+
+@test "_pure_is_inside_container: detect with pid method" (
+    function _pure_detect_container_by_pid_method; echo "called: "(status function); end # spy
+
+    _pure_is_inside_container
+) = "called: _pure_detect_container_by_pid_method"
+
+@test "_pure_is_inside_container: detect with cgroup method" (
+    function _pure_detect_container_by_pid_method; false; end # spy
+    function _pure_detect_container_by_cgroup_method; echo "called: "(status function); end # spy
+
+    _pure_is_inside_container
+) = "called: _pure_detect_container_by_cgroup_method"
 
 
 teardown

--- a/tests/_pure_is_inside_container.test.fish
+++ b/tests/_pure_is_inside_container.test.fish
@@ -16,6 +16,12 @@ function setup
 end
 setup
 
+function before_each
+    functions --erase _pure_detect_container_by_pid_method
+    functions --erase _pure_detect_container_by_cgroup_method
+    functions --erase  uname
+end
+
 function teardown
     rm -rf \
         $namespace \
@@ -28,18 +34,29 @@ end
     _pure_is_inside_container
 ) $status -eq $SUCCESS
 
+before_each
 @test "_pure_is_inside_container: detect with pid method" (
     function _pure_detect_container_by_pid_method; echo "called: "(status function); end # spy
 
     _pure_is_inside_container
 ) = "called: _pure_detect_container_by_pid_method"
 
+before_each
 @test "_pure_is_inside_container: detect with cgroup method" (
     function _pure_detect_container_by_pid_method; false; end # spy
     function _pure_detect_container_by_cgroup_method; echo "called: "(status function); end # spy
 
     _pure_is_inside_container
 ) = "called: _pure_detect_container_by_cgroup_method"
+
+before_each
+@test "_pure_is_inside_container: skip pid method on MacOS" (
+    function uname; echo "Darwin"; end # mock
+    function _pure_detect_container_by_pid_method; echo "should not be called"; end # spy
+    function _pure_detect_container_by_cgroup_method; echo "dummy output"; end # spy
+
+    _pure_is_inside_container
+) != "called: _pure_detect_container_by_pid_method"
 
 
 teardown

--- a/tests/_pure_is_inside_container.test.fish
+++ b/tests/_pure_is_inside_container.test.fish
@@ -49,14 +49,5 @@ before_each
     _pure_is_inside_container
 ) = "called: _pure_detect_container_by_cgroup_method"
 
-before_each
-@test "_pure_is_inside_container: skip pid method on MacOS" (
-    function uname; echo "Darwin"; end # mock
-    function _pure_detect_container_by_pid_method; echo "should not be called"; end # spy
-    function _pure_detect_container_by_cgroup_method; echo "dummy output"; end # spy
-
-    _pure_is_inside_container
-) != "called: _pure_detect_container_by_pid_method"
-
 
 teardown

--- a/tests/_pure_prompt_container.test.fish
+++ b/tests/_pure_prompt_container.test.fish
@@ -2,6 +2,8 @@ source (dirname (status filename))/fixtures/constants.fish
 source (dirname (status filename))/../functions/_pure_is_inside_container.fish
 source (dirname (status filename))/../functions/_pure_user_at_host.fish
 source (dirname (status filename))/../functions/_pure_prompt_container.fish
+source (dirname (status filename))/../functions/_pure_detect_container_by_pid_method.fish
+source (dirname (status filename))/../functions/_pure_detect_container_by_cgroup_method.fish
 @echo (_print_filename (status filename))
 
 


### PR DESCRIPTION
**related:** fixes #295

- chore: bump version 4.2.1
- test: verify we call the detection methods
- test: restrict _pure_detect_container_by_pid_method to non-MacOS
