### PR TITLE
fix/macos container detection error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,16 @@ jobs:
       - run: docker --version
       - run: make test-pure-on FISH_VERSION=${{ matrix.fish_version }}
 
+  test-macos:
+      name: Test on fish on MacOS
+      runs-on: macos-latest
+      steps:
+        - uses: actions/checkout@v2
+        - name: Install Fish
+          run: brew install fish
+        - name: Install Fisher > Fishtape > Pure
+          run: curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher jorgebucaran/fishtape ./
+          shell: fish {0}
+        - name: Test Pure
+          run: fishtape tests/*.test.fish
+          shell: fish {0}

--- a/functions/_pure_detect_container_by_cgroup_method.fish
+++ b/functions/_pure_detect_container_by_cgroup_method.fish
@@ -3,7 +3,6 @@ function _pure_detect_container_by_cgroup_method \
     --argument-names cgroup_namespace
     set --query cgroup_namespace[1]; or set cgroup_namespace /proc/1/cgroup
 
-    # echo "cgroup_namespace: $cgroup_namespace"
     string match \
         --quiet \
         --entire \

--- a/functions/_pure_detect_container_by_pid_method.fish
+++ b/functions/_pure_detect_container_by_pid_method.fish
@@ -3,15 +3,9 @@ function _pure_detect_container_by_pid_method \
 
     set --query proc_sched[1]; or set proc_sched /proc/1/sched
 
-    set --local os_name (uname -s)
-    if test $os_name != "Darwin"
-        head -n 1 $proc_sched \
-            | string match \
-            --quiet \
-            --invert \
-            --regex 'init|systemd'
-    else
-        set --local failure 1
-        return $failure
-    end
+    head -n 1 $proc_sched \
+        | string match \
+        --quiet \
+        --invert \
+        --regex 'init|systemd'
 end

--- a/functions/_pure_is_inside_container.fish
+++ b/functions/_pure_is_inside_container.fish
@@ -7,12 +7,15 @@ function _pure_is_inside_container \
         return $success
     end
 
-    if _pure_detect_container_by_pid_method
-        return $success
-    end
+    set --local os_name (uname -s)
+    if test $os_name = "Linux"
+        if _pure_detect_container_by_pid_method
+            return $success
+        end
 
-    if _pure_detect_container_by_cgroup_method $cgroup_namespace
-        return $success
+        if _pure_detect_container_by_cgroup_method $cgroup_namespace
+            return $success
+        end
     end
 
     set --local failure 1

--- a/functions/_pure_is_inside_container.fish
+++ b/functions/_pure_is_inside_container.fish
@@ -8,7 +8,7 @@ function _pure_is_inside_container \
     end
 
     set --local os_name (uname -s)
-    if test $os_name = "Linux"
+    if test $os_name = Linux
         if _pure_detect_container_by_pid_method
             return $success
         end

--- a/functions/_pure_prompt_container.fish
+++ b/functions/_pure_prompt_container.fish
@@ -1,6 +1,4 @@
 function _pure_prompt_container
-    _pure_is_inside_container
-    echo _pure_is_inside_container $status
     if _pure_is_inside_container
         echo (_pure_user_at_host)
     end

--- a/tests/_pure_detect_container_by_cgroup_method.test.fish
+++ b/tests/_pure_detect_container_by_cgroup_method.test.fish
@@ -21,29 +21,37 @@ function teardown
     set --erase namespace
 end
 
+if test (uname -s) = "Linux"
 @test "_pure_detect_container_by_cgroup_method: false for host OS" (
     echo "1:name=systemd:/init.scope" > $cgroup_namespace
     set --global container $EMPTY
 
     _pure_detect_container_by_cgroup_method $cgroup_namespace
 ) $status -eq $FAILURE
+end
 
+if test (uname -s) = "Linux"
 @test "_pure_detect_container_by_cgroup_method: true for Docker's container" (
     echo "1:name=systemd:/docker/54c541…af18c609c" > $cgroup_namespace
 
     _pure_detect_container_by_cgroup_method $cgroup_namespace
 ) $status -eq $SUCCESS
+end
 
+if test (uname -s) = "Linux"
 @test "_pure_detect_container_by_cgroup_method: true for LXC/LXD's container (using namespace detail)" (
     echo "1:name=systemd:/lxc/54c541…af18c609c" > $cgroup_namespace
 
     _pure_detect_container_by_cgroup_method $cgroup_namespace
 ) $status -eq $SUCCESS
+end
 
+if test (uname -s) = "Linux"
 @test "_pure_detect_container_by_cgroup_method: true for LXC/LXD's container (using environment variable)" (
     set --global container 'lxc'
 
     _pure_detect_container_by_cgroup_method $cgroup_namespace
 ) $status -eq $SUCCESS
+end
 
 teardown

--- a/tests/_pure_detect_container_by_pid_method.test.fish
+++ b/tests/_pure_detect_container_by_pid_method.test.fish
@@ -13,31 +13,32 @@ function teardown
     functions --erase  uname
 end
 
+if test (uname -s) = "Linux"
 @test "_pure_detect_container_by_pid_method: true for init" (
     set --local proc_sched /proc/1/sched
     echo "init (1, #threads: 1)" >$proc_sched
 
     _pure_detect_container_by_pid_method $proc_sched
 ) $status -eq $SUCCESS
+end
 
+if test (uname -s) = "Linux"
 @test "_pure_detect_container_by_pid_method: true for systemd" (
     set --local proc_sched /proc/1/sched
     echo "systemd (1, #threads: 1)" >$proc_sched
 
     _pure_detect_container_by_pid_method $proc_sched
 ) $status -eq $SUCCESS
+end
 
+if test (uname -s) = "Linux"
 @test "_pure_detect_container_by_pid_method: true for Github Action" (
     set --local proc_sched /proc/1/sched
     echo "systemd (1, #threads: 1)" >$proc_sched
 
     _pure_detect_container_by_pid_method $proc_sched
 ) $status -eq $SUCCESS
+end
 
-@test "_pure_detect_container_by_pid_method: skip pid method on MacOS" (
-    function uname; echo "Darwin"; end # mock
-
-    _pure_detect_container_by_pid_method
-) $status -eq $FAILURE
 
 teardown

--- a/tests/_pure_is_inside_container.test.fish
+++ b/tests/_pure_is_inside_container.test.fish
@@ -19,7 +19,8 @@ setup
 function before_each
     functions --erase _pure_detect_container_by_pid_method
     functions --erase _pure_detect_container_by_cgroup_method
-    functions --erase  uname
+    functions --erase uname
+    set --global container ""
 end
 
 function teardown
@@ -34,23 +35,29 @@ end
     _pure_is_inside_container
 ) $status -eq $SUCCESS
 
-if test (uname -s) = "Linux"
-before_each
-@test "_pure_is_inside_container: detect with pid method" (
-function _pure_detect_container_by_pid_method; echo "called: "(status function); end # spy
-
-_pure_is_inside_container
-) = "called: _pure_detect_container_by_pid_method"
-end
-
-if test (uname -s) = "Linux"
-before_each
-@test "_pure_is_inside_container: detect with cgroup method" (
-    function _pure_detect_container_by_pid_method; false; end # spy
-    function _pure_detect_container_by_cgroup_method; echo "called: "(status function); end # spy
+@test "_pure_is_inside_container: detect with $container variable" (
+    set --global container "fake"
 
     _pure_is_inside_container
-) = "called: _pure_detect_container_by_cgroup_method"
+) $status -eq $SUCCESS
+
+if test (uname -s) = Linux
+    before_each
+    @test "_pure_is_inside_container: detect with pid method" (
+    function _pure_detect_container_by_pid_method; echo "called: "(status function); end # spy
+
+    _pure_is_inside_container
+    ) = "called: _pure_detect_container_by_pid_method"
+end
+
+if test (uname -s) = Linux
+    before_each
+    @test "_pure_is_inside_container: detect with cgroup method" (
+        function _pure_detect_container_by_pid_method; false; end # spy
+        function _pure_detect_container_by_cgroup_method; echo "called: "(status function); end # spy
+
+        _pure_is_inside_container
+    ) = "called: _pure_detect_container_by_cgroup_method"
 end
 
 

--- a/tests/_pure_is_inside_container.test.fish
+++ b/tests/_pure_is_inside_container.test.fish
@@ -34,13 +34,16 @@ end
     _pure_is_inside_container
 ) $status -eq $SUCCESS
 
+if test (uname -s) = "Linux"
 before_each
 @test "_pure_is_inside_container: detect with pid method" (
-    function _pure_detect_container_by_pid_method; echo "called: "(status function); end # spy
+function _pure_detect_container_by_pid_method; echo "called: "(status function); end # spy
 
-    _pure_is_inside_container
+_pure_is_inside_container
 ) = "called: _pure_detect_container_by_pid_method"
+end
 
+if test (uname -s) = "Linux"
 before_each
 @test "_pure_is_inside_container: detect with cgroup method" (
     function _pure_detect_container_by_pid_method; false; end # spy
@@ -48,6 +51,7 @@ before_each
 
     _pure_is_inside_container
 ) = "called: _pure_detect_container_by_cgroup_method"
+end
 
 
 teardown

--- a/tests/fish_prompt.test.fish
+++ b/tests/fish_prompt.test.fish
@@ -6,6 +6,9 @@ source (dirname (status filename))/../functions/_pure_is_single_line_prompt.fish
 
 
 function before_all
+    _purge_configs
+    _disable_colors
+
     function _pure_prompt_beginning --description "stub function"
         echo '['
     end

--- a/tests/pure_tools_installer.test.fish
+++ b/tests/pure_tools_installer.test.fish
@@ -24,7 +24,7 @@ function before_each
     _disable_colors
 
     if test "$USER" = nemo
-        rm --force $HOME/.config/fish/config.fish
+        rm -f $HOME/.config/fish/config.fish
         touch $HOME/.config/fish/config.fish
         remove_pure_files
         remove_fish_prompt_files
@@ -83,7 +83,7 @@ before_each
 before_each
 @test "installer: backup existing theme prompt" (
     touch $FISH_CONFIG_DIR/functions/fish_prompt.fish
-    rm --force $FISH_CONFIG_DIR/functions/fish_prompt.fish.ignore
+    rm -f $FISH_CONFIG_DIR/functions/fish_prompt.fish.ignore
 
     pure_backup_existing_theme >/dev/null
 ) -e "$FISH_CONFIG_DIR/functions/fish_prompt.fish.ignore"

--- a/tools/migration-to-4.0.0.fish
+++ b/tools/migration-to-4.0.0.fish
@@ -10,7 +10,11 @@ end
 printf "%sMigrating configuration: $fish_user_config\n"
 
 printf (set_color cyan)"Renaming SSH variables\n"(set_color normal)
-sed -i 's/pure_color_ssh_hostname/pure_color_hostname/g' $fish_user_config #; grep -c 'pure_color_ssh_host' $fish_user_config
-sed -i 's/pure_color_ssh_separator/pure_color_at_sign/g' $fish_user_config #; grep -c 'pure_color_ssh_root' $fish_user_config
-sed -i 's/pure_color_ssh_user_normal/pure_color_username_normal/g' $fish_user_config #; grep -c 'pure_color_ssh_separator' $fish_user_config
-sed -i 's/pure_color_ssh_user_root/pure_color_username_root/g' $fish_user_config #; grep -c 'pure_color_ssh_username' $fish_user_config
+sed 's/pure_color_ssh_hostname/pure_color_hostname/g' $fish_user_config > $fish_user_config.new #; grep -c 'pure_color_ssh_host' $fish_user_config
+mv $fish_user_config.new $fish_user_config # for portability with MacOS
+sed 's/pure_color_ssh_separator/pure_color_at_sign/g' $fish_user_config > $fish_user_config.new #; grep -c 'pure_color_ssh_root' $fish_user_config
+mv $fish_user_config.new $fish_user_config # for portability with MacOS
+sed 's/pure_color_ssh_user_normal/pure_color_username_normal/g' $fish_user_config > $fish_user_config.new #; grep -c 'pure_color_ssh_separator' $fish_user_config
+mv $fish_user_config.new $fish_user_config # for portability with MacOS
+sed 's/pure_color_ssh_user_root/pure_color_username_root/g' $fish_user_config > $fish_user_config.new #; grep -c 'pure_color_ssh_username' $fish_user_config
+mv $fish_user_config.new $fish_user_config # for portability with MacOS


### PR DESCRIPTION
**related:** #295

- fix: use /proc/-based detection only on Linux
- chore: cleanup _pure_prompt_container
