### PR TITLE
fish_title: add setting to configure pwd dir length

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Fully **customizable** (colors, symbols and features):
   - Change `❯` to red when previous command has failed ;
   - Start prompt with _current working directory_ 🏴 ;
   - Compact-mode (single-line prompt) 🏴 ;
-- Display current directory tail ;
+- Display _current folder_  tail ;
 - check for new release on start 🏴 ;
 - Display _username_ and _hostname_ when in an `SSH` session ;
 - Display command _duration_ when longer than `5` seconds ;
@@ -55,7 +55,8 @@ Fully **customizable** (colors, symbols and features):
   - Display `⇣` when branch is _behind_ (commits to pull) ;
   - Async update when [configured with fish-async-prompt](https://github.com/pure-fish/pure/wiki/Async-git-Prompt) ;
 - Update terminal title with _current folder_ and _command_ ;
-- Detect when running in a container
+- Detect when running in a container ;
+- Shorten _current folder_ component 🏳️;
 
 🏴: Enabled or disabled via a [feature flag](#-features-flags).
 
@@ -97,6 +98,8 @@ You can tweak `pure` behavior and color by changing [universal variables](https:
 | **`pure_show_subsecond_command_duration`**     | `false` | Show subsecond (ex. 1.5s) in command duration.                                                  |
 | **`pure_show_system_time`**                    | `false` | `true`: shows system time before the prompt symbol (as `%H:%M:%S`).                             |
 | **`pure_threshold_command_duration`**          | `5`     | Show command duration when above this value (seconds).                                          |
+| **`pure_shorten_prompt_current_directory_length`** | `0` | Shorten every prompt path component but the last to X characters (0 do not shorten)             |
+| **`pure_shorten_window_title_current_directory_length`** | `0` | Shorten every window title path component but the last to X characters (0 do not shorten) |
 
 ### 🎨 Colours
 

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -19,6 +19,7 @@ _pure_set_default pure_color_prompt_on_success pure_color_success
 
 # Current Working Directory
 _pure_set_default pure_color_current_directory pure_color_primary
+_pure_set_default pure_shorten_prompt_current_directory_length 0
 
 # Git
 _pure_set_default pure_enable_git true
@@ -71,6 +72,7 @@ _pure_set_default pure_reverse_prompt_symbol_in_vimode true
 
 # Title
 _pure_set_default pure_symbol_title_bar_separator -
+_pure_set_default pure_shorten_window_title_current_directory_length 0
 
 # Check for new release on startup
 _pure_set_default pure_check_for_new_release false

--- a/functions/_pure_parse_directory.fish
+++ b/functions/_pure_parse_directory.fish
@@ -2,12 +2,12 @@ function _pure_parse_directory \
     --description "Replace '$HOME' with '~'" \
     --argument-names max_path_length
 
-    set --local folder (string replace $HOME '~' $PWD)
-    
+    set --local folder (fish_prompt_pwd_dir_length=$pure_shorten_prompt_current_directory_length prompt_pwd)
+
     if test -n "$max_path_length";
         if test (string length $folder) -gt $max_path_length;
-            # If path exceeds maximum symbol limit, use default fish path formating function
-            set folder (prompt_pwd)
+            # If path exceeds maximum symbol limit, force fish path formating function to use 1 character
+            set folder (fish_prompt_pwd_dir_length=1 prompt_pwd)
         end
     end
     echo $folder

--- a/functions/fish_title.fish
+++ b/functions/fish_title.fish
@@ -2,11 +2,10 @@ function fish_title \
     --description "Set title to current folder and shell name" \
     --argument-names last_command
 
-    set --local basename (string replace --regex '^.*/' '' -- $PWD)
-    set --local current_folder (_pure_parse_directory)
+    set --local current_folder (fish_prompt_pwd_dir_length=$pure_shorten_window_title_current_directory_length prompt_pwd)
     set --local current_command (status current-command 2>/dev/null; or echo $_)
 
-    set --local prompt "$basename: $last_command $pure_symbol_title_bar_separator $current_command"
+    set --local prompt "$current_folder: $last_command $pure_symbol_title_bar_separator $current_command"
 
     if test -z "$last_command"
         set prompt "$current_folder $pure_symbol_title_bar_separator $current_command"

--- a/tests/_pure_parse_directory.test.fish
+++ b/tests/_pure_parse_directory.test.fish
@@ -26,3 +26,12 @@ end; setup
 @test '_pure_parse_directory: shortens directory in prompt' (
     string length (_pure_parse_directory 1)
 ) -lt (string length $PWD)
+
+@test '_pure_parse_directory: shorten current directory' (
+    set --universal pure_shorten_prompt_current_directory_length 2
+
+    mkdir -p /tmp/current/directory/
+    cd /tmp/current/directory/
+
+    _pure_parse_directory
+) = "/tm/cu/directory"

--- a/tests/fish_title.test.fish
+++ b/tests/fish_title.test.fish
@@ -7,18 +7,12 @@ function setup
     mkdir -p /tmp/current/directory/
     cd /tmp/current/directory/
 
-    function _pure_parse_directory; echo /tmp/current/directory; end
 end; setup
-
-function teardown
-    functions --erase _pure_parse_directory
-end
-
 
 @test "fish_title: contains current directory and previous command" (
     set --universal pure_symbol_title_bar_separator '-'
     fish_title 'last-command'
-) = "directory: last-command - fish"
+) = "/tmp/current/directory: last-command - fish"
 
 @test "fish_title: contains current directory with an *empty* previous command" (
     fish_title ''
@@ -29,5 +23,12 @@ end
     fish_title
 ) = "/tmp/current/directory - fish"
 
+@test "fish_title: contains shorten (1) current path" (
+    set --universal pure_shorten_window_title_current_directory_length 1
+    fish_title
+) = "/t/c/directory - fish"
 
-teardown
+@test "fish_title: contains shorten (2) current path" (
+    set --universal pure_shorten_window_title_current_directory_length 2
+    fish_title
+) = "/tm/cu/directory - fish"


### PR DESCRIPTION
Add new pure_title_dir_length setting (default to 0) to configure the pwd dir length. 0 means complete directory name.

example with path '/foo/example/bar':
* pure_title_dir_length=0 -> '/foo/example/bar'
* pure_title_dir_length=1 -> '/f/e/bar'
* pure_title_dir_length=2 -> '/fo/ex/bar'