### PR TITLE
feat/support symbol for ssh and container

### DIFF
--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --global pure_version 4.3.1 # For bug report and tag-after-merge workflow
+set --global pure_version 4.4.0 # For bug report and tag-after-merge workflow
 
 # Base colors
 _pure_set_default pure_color_primary blue

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -85,3 +85,7 @@ _pure_set_default pure_enable_single_line_prompt false
 
 # Detect when running in container (e.g. docker, podman, LXC/LXD)
 _pure_set_default pure_enable_container_detection true
+_pure_set_default pure_symbol_container_prefix "" # suggestion: '🐋' or '📦'
+
+# Detect when running in SSH
+_pure_set_default pure_symbol_ssh_prefix "" # suggestion: 'ssh:/' or '🔗🔐🔒🌐'

--- a/functions/_pure_prompt_container.fish
+++ b/functions/_pure_prompt_container.fish
@@ -1,5 +1,5 @@
 function _pure_prompt_container
     if _pure_is_inside_container
-        echo (_pure_user_at_host)
+        echo "$pure_symbol_container_prefix"(_pure_user_at_host)
     end
 end

--- a/functions/_pure_prompt_ssh.fish
+++ b/functions/_pure_prompt_ssh.fish
@@ -1,5 +1,5 @@
 function _pure_prompt_ssh
     if test "$SSH_CONNECTION" != ""
-        echo (_pure_user_at_host)
+        echo "$pure_symbol_ssh_prefix"(_pure_user_at_host)
     end
 end

--- a/tests/_pure.test.fish
+++ b/tests/_pure.test.fish
@@ -6,21 +6,22 @@ source (dirname (status filename))/../functions/_pure_set_default.fish
 function setup
     _purge_configs
     _disable_colors
-end; setup
+end
+setup
 
-@test "configure: pure_version"  (
+@test "configure: pure_version" (
     set --erase pure_version
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_version
 ) != $EMPTY
 
-@test "configure: pure_symbol_prompt"  (
+@test "configure: pure_symbol_prompt" (
     set --erase pure_symbol_prompt
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_symbol_prompt
 ) = "❯"
 
-@test "configure: pure_symbol_reverse_prompt"  (
+@test "configure: pure_symbol_reverse_prompt" (
     set --erase pure_symbol_reverse_prompt
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_symbol_reverse_prompt
@@ -32,223 +33,223 @@ end; setup
     echo $pure_reverse_prompt_symbol_in_vimode
 ) = true
 
-@test "configure: pure_enable_git"  (
+@test "configure: pure_enable_git" (
     set --erase pure_enable_git
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_enable_git
 ) = true
 
-@test "configure: pure_symbol_git_unpulled_commits"  (
+@test "configure: pure_symbol_git_unpulled_commits" (
     set --erase pure_symbol_git_unpulled_commits
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_symbol_git_unpulled_commits
 ) = "⇣"
 
-@test "configure: pure_symbol_git_unpushed_commits"  (
+@test "configure: pure_symbol_git_unpushed_commits" (
     set --erase pure_symbol_git_unpushed_commits
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_symbol_git_unpushed_commits
 ) = "⇡"
 
-@test "configure: pure_symbol_git_dirty"  (
+@test "configure: pure_symbol_git_dirty" (
     set --erase pure_symbol_git_dirty
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_symbol_git_dirty
 ) = "*"
 
-@test "configure: pure_symbol_git_stash"  (
+@test "configure: pure_symbol_git_stash" (
     set --erase pure_symbol_git_stash
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_symbol_git_stash
 ) = "≡"
 
-@test "configure: pure_symbol_title_bar_separator"  (
+@test "configure: pure_symbol_title_bar_separator" (
     set --erase pure_symbol_title_bar_separator
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_symbol_title_bar_separator
-) = "-"
+) = -
 
-@test "configure: pure_color_primary"  (
+@test "configure: pure_color_primary" (
     set --erase pure_color_primary
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_primary
 ) = blue
 
-@test "configure: pure_color_info"  (
+@test "configure: pure_color_info" (
     set --erase pure_color_info
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_info
 ) = cyan
 
-@test "configure: pure_color_mute"  (
+@test "configure: pure_color_mute" (
     set --erase pure_color_mute
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_mute
 ) = brblack
 
-@test "configure: pure_color_success"  (
+@test "configure: pure_color_success" (
     set --erase pure_color_success
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_success
 ) = magenta
 
-@test "configure: pure_color_normal"  (
+@test "configure: pure_color_normal" (
     set --erase pure_color_normal
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_normal
 ) = normal
 
-@test "configure: pure_color_danger"  (
+@test "configure: pure_color_danger" (
     set --erase pure_color_danger
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_danger
 ) = red
 
-@test "configure: pure_color_light"  (
+@test "configure: pure_color_light" (
     set --erase pure_color_light
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_light
 ) = white
 
-@test "configure: pure_color_warning"  (
+@test "configure: pure_color_warning" (
     set --erase pure_color_warning
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_warning
 ) = yellow
 
-@test "configure: pure_color_command_duration"  (
+@test "configure: pure_color_command_duration" (
     set --erase pure_color_command_duration
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_command_duration
 ) = pure_color_warning
 
-@test "configure: pure_color_current_directory"  (
+@test "configure: pure_color_current_directory" (
     set --erase pure_color_current_directory
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_current_directory
 ) = pure_color_primary
 
-@test "configure: pure_color_git_unpushed_commits"  (
+@test "configure: pure_color_git_unpushed_commits" (
     set --erase pure_color_git_unpushed_commits
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_git_unpushed_commits
 ) = pure_color_info
 
-@test "configure: pure_color_git_unpulled_commits"  (
+@test "configure: pure_color_git_unpulled_commits" (
     set --erase pure_color_git_unpulled_commits
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_git_unpulled_commits
 ) = pure_color_info
 
-@test "configure: pure_color_git_branch"  (
+@test "configure: pure_color_git_branch" (
     set --erase pure_color_git_branch
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_git_branch
 ) = pure_color_mute
 
-@test "configure: pure_color_git_dirty"  (
+@test "configure: pure_color_git_dirty" (
     set --erase pure_color_git_dirty
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_git_dirty
 ) = pure_color_mute
 
-@test "configure: pure_color_git_stash"  (
+@test "configure: pure_color_git_stash" (
     set --erase pure_color_git_stash
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_git_stash
 ) = pure_color_info
 
-@test "configure: pure_color_hostname"  (
+@test "configure: pure_color_hostname" (
     set --erase pure_color_hostname
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_hostname
 ) = pure_color_mute
 
-@test "configure: pure_color_at_sign"  (
+@test "configure: pure_color_at_sign" (
     set --erase pure_color_at_sign
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_at_sign
 ) = pure_color_mute
 
-@test "configure: pure_color_username_normal"  (
+@test "configure: pure_color_username_normal" (
     set --erase pure_color_username_normal
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_username_normal
 ) = pure_color_mute
 
-@test "configure: pure_color_username_root"  (
+@test "configure: pure_color_username_root" (
     set --erase pure_color_username_root
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_username_root
 ) = pure_color_light
 
-@test "configure: pure_color_prompt_on_error"  (
+@test "configure: pure_color_prompt_on_error" (
     set --erase pure_color_prompt_on_error
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_prompt_on_error
 ) = pure_color_danger
 
-@test "configure: pure_color_prompt_on_success"  (
+@test "configure: pure_color_prompt_on_success" (
     set --erase pure_color_prompt_on_success
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_prompt_on_success
 ) = pure_color_success
 
-@test "configure: pure_show_jobs"  (
+@test "configure: pure_show_jobs" (
     set --erase pure_show_jobs
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_show_jobs
 ) = false
 
-@test "configure: pure_color_jobs"  (
+@test "configure: pure_color_jobs" (
     set --erase pure_color_jobs
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_jobs
 ) = pure_color_normal
 
-@test "configure: pure_show_system_time"  (
+@test "configure: pure_show_system_time" (
     set --erase pure_show_system_time
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_show_system_time
 ) = false
 
-@test "configure: pure_color_system_time"  (
+@test "configure: pure_color_system_time" (
     set --erase pure_color_system_time
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_system_time
 ) = pure_color_mute
 
-@test "configure: pure_color_virtualenv"  (
+@test "configure: pure_color_virtualenv" (
     set --erase pure_color_virtualenv
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_virtualenv
 ) = pure_color_mute
 
-@test "configure: pure_begin_prompt_with_current_directory"  (
+@test "configure: pure_begin_prompt_with_current_directory" (
     set --erase pure_begin_prompt_with_current_directory
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_begin_prompt_with_current_directory
 ) = true
 
-@test "configure: pure_separate_prompt_on_error"  (
+@test "configure: pure_separate_prompt_on_error" (
     set --erase pure_separate_prompt_on_error
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_separate_prompt_on_error
 ) = false
 
-@test "configure: pure_threshold_command_duration"  (
+@test "configure: pure_threshold_command_duration" (
     set --erase pure_threshold_command_duration
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_threshold_command_duration
 ) = 5
 
-@test "configure: pure_show_subsecond_command_duration"  (
+@test "configure: pure_show_subsecond_command_duration" (
     set --erase pure_show_subsecond_command_duration
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_show_subsecond_command_duration
 ) = false
 
-@test "configure: pure_color_command_duration"  (
+@test "configure: pure_color_command_duration" (
     set --erase pure_color_command_duration
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_color_command_duration

--- a/tests/_pure.test.fish
+++ b/tests/_pure.test.fish
@@ -290,3 +290,14 @@ end; setup
     echo $pure_enable_container_detection
 ) = true
 
+@test "configure: pure_symbol_container_prefix" (
+    set --erase pure_symbol_container_prefix
+    source (dirname (status filename))/../conf.d/pure.fish
+    echo $pure_symbol_container_prefix
+) = ""
+
+@test "configure: pure_symbol_ssh_prefix" (
+    set --erase pure_symbol_ssh_prefix
+    source (dirname (status filename))/../conf.d/pure.fish
+    echo $pure_symbol_ssh_prefix
+) = ""

--- a/tests/_pure_prompt_container.test.fish
+++ b/tests/_pure_prompt_container.test.fish
@@ -12,9 +12,16 @@ function before_each
     _disable_colors
 end
 
-before_each
 if test "$USER" = nemo
+    before_each
     @test "_pure_prompt_container: displays 'user@hostname' when inside container" (
-    string match --quiet --regex "$USER@[\w]+" (_pure_prompt_container)
+        string match --quiet --regex "$USER@[\w]+" (_pure_prompt_container)
+    ) $status -eq $SUCCESS
+
+    before_each
+    @test "_pure_prompt_container: displays container prefix when inside container" (
+        set --universal pure_symbol_container_prefix "🐋"
+
+        string match --quiet --regex "🐋" (_pure_prompt_container)
     ) $status -eq $SUCCESS
 end

--- a/tests/_pure_prompt_ssh.test.fish
+++ b/tests/_pure_prompt_ssh.test.fish
@@ -4,10 +4,11 @@ source (dirname (status filename))/../functions/_pure_user_at_host.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_each
     _purge_configs
     _disable_colors
-end; setup
+end
+before_each
 
 
 @test "_pure_prompt_ssh: hide 'user@hostname' when working locally" (
@@ -22,4 +23,12 @@ end; setup
 
     string match --quiet --regex 'user@[\w]+' (_pure_prompt_ssh)
     # $hostname is read-only, we cant determine it preceisely (e.g. is dynamic in docker container)
+) $status -eq $SUCCESS
+
+@test "_pure_prompt_ssh: displays ssh prefix when SSH connection detected" (
+    set SSH_CONNECTION 127.0.0.1 56422 127.0.0.1 22
+    function id; echo 'user'; end  # mock
+    set --universal pure_symbol_ssh_prefix "ssh:/"
+
+    string match --quiet --regex 'ssh:/' (_pure_prompt_ssh)
 ) $status -eq $SUCCESS


### PR DESCRIPTION
- fix: use /proc/-based detection only on Linux
- chore: cleanup _pure_prompt_container
- ci: add macos job
- fix: remove long option for `rm`
- fix(macos): use portable `sed command`
- test: reset config and disable color
- test: verify container detection method with $container variable
- chore: bump version 4.2.3
- fix(container): priorize /proc/1/cgroup detection over /proc/1/sched/
- docs(flag): add `pure_enable_container_detection`
- docs: typos
- test(container): check default value for `pure_enable_container_detection`
- feat(container): implement `pure_enable_container_detection` feature flag
- refactor: restrict container detection by pid only when required file exists
- test: show debug if spy function was not called
- chore(release): add releaser script
- ci: skip `releaser.fish` test using --regex flag of `string replace` (fish added in 3.2.0)
- chore: bump version 4.3.0
- ci: fix action-autotag
- fix(prompt): remove unwanted characters in my prompt
- fix(releaser): stop amending previous commit when bumping version
- chore(releaser): add `make release VERSION=1.2.3` task
- chore: bump version 4.3.1
- Rename .github/ISSUE_TEMPLATE.md to .github/ISSUE_TEMPLATE/BUG_REPORT.md
- Update BUG_REPORT.md
- docs(readme): replace white flag with black one (for visibility)
- ci: restrict tag on merge when pure config file changes
- ci: restrict ci workflow to *.fish file
- feat(container): add SSH and container symbol customization
- chore(lint): re-format
- chore: bump version 4.4.0
