### PR TITLE
fix: restore fish_prompt to default content after _pure_uninstall run

### DIFF
--- a/conf.d/_pure_init.fish
+++ b/conf.d/_pure_init.fish
@@ -11,4 +11,5 @@ function _pure_uninstall --on-event pure_uninstall
     set --names \
         | string replace --filter --regex '(^_?pure)' 'set --erase $1' \
         | source
+    cp {$__fish_data_dir,$__fish_config_dir}/functions/fish_prompt.fish
 end

--- a/tests/_pure_uninstall.test.fish
+++ b/tests/_pure_uninstall.test.fish
@@ -8,8 +8,26 @@ function setup
 end; setup
 
 
-@test "init: source uninstall handler"  (
+@test "init/_pure_uninstall: handler is available"  (
     functions --erase _pure_uninstall
     source (dirname (status filename))/../conf.d/_pure_init.fish
     functions --query _pure_uninstall
+) $status -eq $SUCCESS
+
+@test "init/_pure_uninstall: restore default 'fish_prompt'"  (
+    functions --erase _pure_uninstall
+    source (dirname (status filename))/../conf.d/_pure_init.fish
+
+    _pure_uninstall
+
+    diff -q {$__fish_data_dir,$__fish_config_dir}/functions/fish_prompt.fish
+) $status -eq $SUCCESS
+
+@test "init/_pure_uninstall: restore a working fish_prompt"  (
+    functions --erase _pure_uninstall
+    source (dirname (status filename))/../conf.d/_pure_init.fish
+
+    _pure_uninstall
+
+    fish_prompt >/dev/null
 ) $status -eq $SUCCESS


### PR DESCRIPTION
closes #314
