### PR TITLE
feat/add kubernetes k8s support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,33 +2,30 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/alpine
 {
     "name": "Alpine",
-    "image": "purefish/docker-fish:3.5.1",
+    "image": "purefish/docker-fish:3.6.1",
     // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
         "ghcr.io/guiyomh/features/vim:0": {}
     },
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [],
-
     // Use 'postCreateCommand' to run commands after the container is created.
     "postCreateCommand": "fish -c 'fisher install pure-fish/pure'",
     "postStartCommand": "fish -c 'echo $pure_version'",
-
     // Configure tool-specific properties.
     // "customizations": {},
-
     // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
     "remoteUser": "nemo",
     "customizations": {
         "vscode": {
             "settings": {
                 "terminal.integrated.defaultProfile.linux": "fish"
-			},
-			"extensions": [
-				"redhat.vscode-yaml",
-				"bierner.markdown-preview-github-styles",
-				"bierner.markdown-emoji"
-			]
+            },
+            "extensions": [
+                "redhat.vscode-yaml",
+                "bierner.markdown-preview-github-styles",
+                "bierner.markdown-emoji"
+            ]
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 > ##### :arrow_up: Hey! Want to migrate from v3.x to v4.x? Check our [**migration guide**](https://github.com/pure-fish/pure/releases/tag/v4.0.0), done with :heart
+>
+> ##### :arrow_up: Hey! Want to migrate from v3.x to v4.x? Check our [**migration guide**](https://github.com/pure-fish/pure/releases/tag/v4.0.0), done with :heart
 
 # pure [![ci-status]][ci-link] ![fish-3] ![GitHub tag (latest SemVer)][badge-version] [![sponsors]][sponsor-link]
 
@@ -44,6 +46,7 @@ Fully **customizable** (colors, symbols and features):
 - Display command _duration_ when longer than `5` seconds ;
 - Display `Python` _virtualenv_ when activated ;
 - Display `VI` mode and custom symbol for non-insert mode 🏴 ;
+- Display `kubernetes` context and namespace
 - Show system time 🏴 ;
 - Show number of running jobs 🏴 ;
 - Prefix when `root` 🏴 ;
@@ -70,16 +73,20 @@ set --universal pure_color_system_time pure_color_mute
 
 ### Prompt Symbol
 
-| Option                                 | Default | Description                                          |
-| :------------------------------------- | :------ | :--------------------------------------------------- |
-| **`pure_symbol_git_dirty`**            | `*`     | Repository is Dirty (uncommitted/untracked changes). |
-| **`pure_symbol_git_stash`**            | `≡`     | Repository git stash status.                         |
-| **`pure_symbol_git_unpulled_commits`** | `⇣`     | Branch is behind upstream (commits to pull).         |
-| **`pure_symbol_git_unpushed_commits`** | `⇡`     | Branch is ahead upstream (commits to push).          |
-| **`pure_symbol_prefix_root_prompt`**   | `#`     | Prefix prompt when logged in as `root`.              |
-| **`pure_symbol_prompt`**               | `❯`     | Prompt symbol.                                       |
-| **`pure_symbol_reverse_prompt`**       | `❮`     | VI non-insert mode symbol.                           |
-| **`pure_symbol_title_bar_separator`**  | `-`     | Separator in terminal's windows title.               |
+| Option                                 | Default | Description                                                         |
+| :------------------------------------- | :------ | :------------------------------------------------------------------ |
+| **`pure_symbol_container_prefix`**     |         | Prefix when being inside a container ([to customize][to-set])       |
+| **`pure_symbol_git_dirty`**            | `*`     | Repository is Dirty (uncommitted/untracked changes).                |
+| **`pure_symbol_git_stash`**            | `≡`     | Repository git stash status.                                        |
+| **`pure_symbol_git_unpulled_commits`** | `⇣`     | Branch is behind upstream (commits to pull).                        |
+| **`pure_symbol_git_unpushed_commits`** | `⇡`     | Branch is ahead upstream (commits to push).                         |
+| **`pure_symbol_k8s_prefix`**           | `☸`     | Prefix when being connected to Kubernetes/K8s                       |
+| **`pure_symbol_prefix_root_prompt`**   | `#`     | Prefix prompt when logged in as `root`.                             |
+| **`pure_symbol_prefix_root_prompt`**   | `#`     | Prefix when being root user                                         |
+| **`pure_symbol_prompt`**               | `❯`     | Prompt symbol.                                                      |
+| **`pure_symbol_reverse_prompt`**       | `❮`     | VI non-insert mode symbol.                                          |
+| **`pure_symbol_ssh_prefix`**           |         | Prefix when being connected to SSH session ([to customize][to-set]) |
+| **`pure_symbol_title_bar_separator`**  | `-`     | Separator in terminal's windows title.                              |
 
 > :information_source: Need [safer `git` symbols](https://github.com/sindresorhus/pure/wiki/Customizations,-hacks-and-tweaks#safer-symbols)?
 
@@ -89,18 +96,19 @@ set --universal pure_color_system_time pure_color_mute
 | :------------------------------------------------------- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **`pure_begin_prompt_with_current_directory`**           | `true`  | `true`: _`pwd` `git`, `SSH`, duration_.<br/>`false`: _`SSH` `pwd` `git`, duration_.                                                                                 |
 | **`pure_check_for_new_release`**                         | `false` | `true`: check repo for new release (on every shell start)                                                                                                           |
-| **`pure_enable_git`**                                    | `true`  | Show info about Git repository.                                                                                                                                     |
 | **`pure_enable_container_detection`**                    | `true`  | `false`: Do not check if run in container (e.g. `docker`, `podman`, `LXC`/`LXD`, etc.).<br/>:warning: Detection is a bit [tricky across OSes][container-detection]. |
+| **`pure_enable_git`**                                    | `true`  | Show info about Git repository.                                                                                                                                     |
+| **`pure_enable_k8s`**                                    | `false` | `true`: shows `kubernetes` context and namespace.                                                                                                                   |
 | **`pure_enable_single_line_prompt`**                     | `false` | `true`: Compact prompt as a single line                                                                                                                             |
 | **`pure_reverse_prompt_symbol_in_vimode`**               | `true`  | `true`: `❮` indicate a non-insert mode.<br/>`false`: indicate vi mode with `[I]`, `[N]`, `[V]`.                                                                     |
 | **`pure_separate_prompt_on_error`**                      | `false` | Show last command [exit code as a separate character][exit-code].                                                                                                   |
+| **`pure_shorten_prompt_current_directory_length`**       | `0`     | Shorten every prompt path component but the last to X characters (0 do not shorten)                                                                                 |
+| **`pure_shorten_window_title_current_directory_length`** | `0`     | Shorten every window title path component but the last to X characters (0 do not shorten)                                                                           |
 | **`pure_show_jobs`**                                     | `false` | Show Number of running jobs                                                                                                                                         |
 | **`pure_show_prefix_root_prompt`**                       | `false` | `true`: shows prompt prefix when logged in as `root`.                                                                                                               |
 | **`pure_show_subsecond_command_duration`**               | `false` | Show subsecond (ex. 1.5s) in command duration.                                                                                                                      |
 | **`pure_show_system_time`**                              | `false` | `true`: shows system time before the prompt symbol (as `%H:%M:%S`).                                                                                                 |
 | **`pure_threshold_command_duration`**                    | `5`     | Show command duration when above this value (seconds).                                                                                                              |
-| **`pure_shorten_prompt_current_directory_length`**       | `0`     | Shorten every prompt path component but the last to X characters (0 do not shorten)                                                                                 |
-| **`pure_shorten_window_title_current_directory_length`** | `0`     | Shorten every window title path component but the last to X characters (0 do not shorten)                                                                           |
 
 ### 🎨 Colours
 
@@ -143,6 +151,7 @@ Specify the [`FISH_VERSION`][fish-releases] you want, and the `CMD` executed by 
 
 [MIT][MIT]
 
+[to-set]: #paintbrush-configuration
 [ci-link]: <https://github.com/pure-fish/pure/actions> "Github CI"
 [ci-status]: https://img.shields.io/github/actions/workflow/status/pure-fish/pure/.github/workflows/ci.yml?style=flat-square
 
@@ -157,4 +166,5 @@ Specify the [`FISH_VERSION`][fish-releases] you want, and the `CMD` executed by 
 [badge-version]: https://img.shields.io/github/v/tag/pure-fish/pure?label=latest%20&style=flat-square
 [sponsors]: https://img.shields.io/github/sponsors/edouard-lopez?label=💰&style=flat-square "GitHub Sponsors"
 [sponsor-link]: https://github.com/sponsors/edouard-lopez/ "Become a sponsor"
+
 [contributing]: CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Fully **customizable** (colors, symbols and features):
 - Display `Python` _virtualenv_ when activated ;
 - Display `VI` mode and custom symbol for non-insert mode 🏴 ;
 - Display `kubernetes` context and namespace
+- Display container indicator (e.g. `docker`, `podman`, `LXC`/`LXD`) 🏴
 - Show system time 🏴 ;
 - Show number of running jobs 🏴 ;
 - Prefix when `root` 🏴 ;
@@ -58,7 +59,7 @@ Fully **customizable** (colors, symbols and features):
   - Async update when [configured with fish-async-prompt](https://github.com/pure-fish/pure/wiki/Async-git-Prompt) ;
 - Update terminal title with _current folder_ and _command_ ;
 - Detect when running in a container ;
-- Shorten _current folder_ component 🏳️;
+- Shorten _current folder_ component 🏴;
 
 🏴: Enabled or disabled via a [feature flag](#-features-flags).
 

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -47,7 +47,7 @@ _pure_set_default pure_color_jobs pure_color_normal
 _pure_set_default pure_show_system_time false
 _pure_set_default pure_color_system_time pure_color_mute
 
-# Virtualenv for Python
+#  env for Python
 _pure_set_default pure_color_virtualenv pure_color_mute
 
 # Print current working directory at the beginning of prompt
@@ -91,3 +91,9 @@ _pure_set_default pure_symbol_container_prefix "" # suggestion: '🐋' or '📦'
 
 # Detect when running in SSH
 _pure_set_default pure_symbol_ssh_prefix "" # suggestion: 'ssh:/' or '🔗🔐🔒🌐'
+
+# Display Kubernetes/k8s context and namespace
+_pure_set_default pure_enable_k8s false
+_pure_set_default pure_symbol_k8s_prefix "☸" # ☸️
+_pure_set_default pure_color_k8s_context pure_color_success
+_pure_set_default pure_color_k8s_namespace pure_color_primary

--- a/functions/_pure_check_availability.fish
+++ b/functions/_pure_check_availability.fish
@@ -1,0 +1,15 @@
+function _pure_check_availability \
+    --description "Ensure command is available on system" \
+    --argument-names \
+    feature_flag \
+    required_command
+
+    set FAILURE 1
+
+    if not type -q $required_command # command, function or alias are OK
+        echo (set_color $pure_color_warning) \
+            "$feature_flag feature requires: `$required_command`" \
+            (set_color $pure_color_normal)
+        return $FAILURE
+    end
+end

--- a/functions/_pure_k8s_context.fish
+++ b/functions/_pure_k8s_context.fish
@@ -1,3 +1,3 @@
 function _pure_k8s_context
-    echo (kubectl config current-context)
+    kubectl config current-context
 end

--- a/functions/_pure_k8s_context.fish
+++ b/functions/_pure_k8s_context.fish
@@ -1,0 +1,3 @@
+function _pure_k8s_context
+    echo (kubectl config current-context)
+end

--- a/functions/_pure_k8s_namespace.fish
+++ b/functions/_pure_k8s_namespace.fish
@@ -1,3 +1,3 @@
 function _pure_k8s_namespace
-    echo (kubectl config view --minify --output 'jsonpath={..namespace}')
+    kubectl config view --minify --output 'jsonpath={..namespace}'
 end

--- a/functions/_pure_k8s_namespace.fish
+++ b/functions/_pure_k8s_namespace.fish
@@ -1,0 +1,3 @@
+function _pure_k8s_namespace
+    echo (kubectl config view --minify --output 'jsonpath={..namespace}')
+end

--- a/functions/_pure_prompt_first_line.fish
+++ b/functions/_pure_prompt_first_line.fish
@@ -5,11 +5,13 @@ function _pure_prompt_first_line \
 
     set --local prompt_ssh (_pure_prompt_ssh)
     set --local prompt_container (_pure_prompt_container)
+    set --local prompt_k8s (_pure_prompt_k8s)
     set --local prompt_git (_pure_prompt_git)
     set --local prompt_command_duration (_pure_prompt_command_duration)
     set --local prompt (_pure_print_prompt \
                             $prompt_ssh \
                             $prompt_container \
+                            $prompt_k8s \
                             $prompt_git \
                             $prompt_command_duration
                         )
@@ -19,18 +21,20 @@ function _pure_prompt_first_line \
     set --local prompt_components
     if set --query pure_begin_prompt_with_current_directory; and test "$pure_begin_prompt_with_current_directory" = true
         set prompt_components \
-                $current_folder \
-                $prompt_git \
-                $prompt_ssh \
-                $prompt_container \
-                $prompt_command_duration
+            $current_folder \
+            $prompt_git \
+            $prompt_ssh \
+            $prompt_container \
+            $prompt_k8s \
+            $prompt_command_duration
     else
         set prompt_components \
-                $prompt_ssh \
-                $prompt_container \
-                $current_folder \
-                $prompt_git \
-                $prompt_command_duration
+            $prompt_ssh \
+            $prompt_container \
+            $prompt_k8s \
+            $current_folder \
+            $prompt_git \
+            $prompt_command_duration
     end
 
     echo (_pure_print_prompt $prompt_components)

--- a/functions/_pure_prompt_k8s.fish
+++ b/functions/_pure_prompt_k8s.fish
@@ -1,5 +1,8 @@
 function _pure_prompt_k8s
-    if $pure_enable_k8s; and _pure_check_availability pure_enable_k8s kubectl
+    if set --query pure_enable_k8s;
+        and test "$pure_enable_k8s" = true;
+        and _pure_check_availability pure_enable_k8s kubectl
+
         set -l context (_pure_set_color $pure_color_k8s_context)(_pure_k8s_context)
         set -l namespace (_pure_set_color $pure_color_k8s_namespace)(_pure_k8s_namespace)
         echo "$pure_symbol_k8s_prefix $context/$namespace"

--- a/functions/_pure_prompt_k8s.fish
+++ b/functions/_pure_prompt_k8s.fish
@@ -1,5 +1,5 @@
 function _pure_prompt_k8s
-    if $pure_enable_k8s; and _pure_check_availability kubectl pure_enable_k8s
+    if $pure_enable_k8s; and _pure_check_availability pure_enable_k8s kubectl
         set -l context (_pure_set_color $pure_color_k8s_context)(_pure_k8s_context)
         set -l namespace (_pure_set_color $pure_color_k8s_namespace)(_pure_k8s_namespace)
         echo "$pure_symbol_k8s_prefix $context/$namespace"

--- a/functions/_pure_prompt_k8s.fish
+++ b/functions/_pure_prompt_k8s.fish
@@ -1,0 +1,7 @@
+function _pure_prompt_k8s
+    if $pure_enable_k8s
+        set -l context (_pure_set_color $pure_color_k8s_context)(_pure_k8s_context)
+        set -l namespace (_pure_set_color $pure_color_k8s_namespace)(_pure_k8s_namespace)
+        echo "$pure_symbol_k8s_prefix $context/$namespace"
+    end
+end

--- a/functions/_pure_prompt_k8s.fish
+++ b/functions/_pure_prompt_k8s.fish
@@ -1,5 +1,5 @@
 function _pure_prompt_k8s
-    if $pure_enable_k8s
+    if $pure_enable_k8s; and _pure_check_availability kubectl pure_enable_k8s
         set -l context (_pure_set_color $pure_color_k8s_context)(_pure_k8s_context)
         set -l namespace (_pure_set_color $pure_color_k8s_namespace)(_pure_k8s_namespace)
         echo "$pure_symbol_k8s_prefix $context/$namespace"

--- a/makefile
+++ b/makefile
@@ -32,6 +32,7 @@ dev-pure-on:
 		--interactive \
 		--tty \
 		--volume=$$(pwd):/home/nemo/.config/fish/ \
+		--workdir /home/nemo/.config/fish/ \
 		pure-on-fish-${FISH_VERSION} "${CMD}"
 	chmod o=r-x tests/fixtures/ # for migration-to-4.0.0.test.fish only
 

--- a/makefile
+++ b/makefile
@@ -31,9 +31,9 @@ dev-pure-on:
 		--rm \
 		--interactive \
 		--tty \
-		--volume=$$(pwd):/home/nemo/.config/fish/ \
-		--workdir /home/nemo/.config/fish/ \
-		pure-on-fish-${FISH_VERSION} "${CMD}"
+		--volume=$$(pwd):/home/nemo/.config/fish/pure/ \
+		--workdir /home/nemo/.config/fish/pure/ \
+		pure-on-fish-${FISH_VERSION} "set --append fish_function_path $$__fish_config_dir/pure; ${CMD}"
 	chmod o=r-x tests/fixtures/ # for migration-to-4.0.0.test.fish only
 
 # Don't override COPY directive as `--volume` doesnt play nice with Travis

--- a/tests/_pure.test.fish
+++ b/tests/_pure.test.fish
@@ -302,3 +302,28 @@ setup
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_symbol_ssh_prefix
 ) = ""
+
+
+@test "configure: pure_enable_k8s" (
+    set --erase pure_enable_k8s
+    source (dirname (status filename))/../conf.d/pure.fish
+    echo $pure_enable_k8s
+) = false
+
+@test "configure: pure_symbol_k8s_prefix" (
+    set --erase pure_symbol_k8s_prefix
+    source (dirname (status filename))/../conf.d/pure.fish
+    echo $pure_symbol_k8s_prefix
+) = "☸"
+
+@test "configure: pure_color_k8s_context" (
+    set --erase pure_color_k8s_context
+    source (dirname (status filename))/../conf.d/pure.fish
+    echo $pure_color_k8s_context
+) = pure_color_success
+
+@test "configure: pure_color_k8s_namespace" (
+    set --erase pure_color_k8s_namespace
+    source (dirname (status filename))/../conf.d/pure.fish
+    echo $pure_color_k8s_namespace
+) = pure_color_primary

--- a/tests/_pure_check_availability.test.fish
+++ b/tests/_pure_check_availability.test.fish
@@ -1,0 +1,27 @@
+source (dirname (status filename))/fixtures/constants.fish
+source (dirname (status filename))/../functions/_pure_check_availability.fish
+@echo (_print_filename (status filename))
+
+
+@test "_pure_check_availability: output help message when command is missing" (
+    set required_command foo-(random)
+    set feature_flag foo
+    
+    set output (_pure_check_availability $feature_flag $required_command)
+
+    string match --quiet --regex "$feature_flag feature requires:" $output
+) $status -eq $SUCCESS
+
+@test "_pure_check_availability: exit with failure when command is missing" (
+    set required_command foo-(random)
+    set feature_flag foo
+    
+    _pure_check_availability $feature_flag $required_command &> /dev/null
+) $status -eq $FAILURE
+
+@test "_pure_check_availability: exit with success when command is available" (
+    set required_command ls
+    set feature_flag foo
+
+    _pure_check_availability $feature_flag $required_command
+) $status -eq $SUCCESS

--- a/tests/_pure_k8s_context.test.fish
+++ b/tests/_pure_k8s_context.test.fish
@@ -1,4 +1,5 @@
 source (dirname (status filename))/fixtures/constants.fish
+source (dirname (status filename))/mocks/mocks.fish
 source (dirname (status filename))/../functions/_pure_k8s_context.fish
 @echo (_print_filename (status filename))
 
@@ -11,12 +12,11 @@ end
 
 before_each
 @test "_pure_k8s_context: return context" (
-    function kubectl
-        echo foo-bar-cluster-eu-west-3
-    end # mock
+    _mock kubectl
+
 
     _pure_k8s_context
-) = foo-bar-cluster-eu-west-3
+) = my-context
 
 before_each
 @test "_pure_k8s_context: call `kubectl config current-context`" (

--- a/tests/_pure_k8s_context.test.fish
+++ b/tests/_pure_k8s_context.test.fish
@@ -1,0 +1,27 @@
+source (dirname (status filename))/fixtures/constants.fish
+source (dirname (status filename))/../functions/_pure_k8s_context.fish
+@echo (_print_filename (status filename))
+
+
+function before_each
+    functions --erase head
+    _cleanup_calls
+end
+
+
+before_each
+@test "__pure_k8s_context: return context" (
+    function kubectl
+        echo foo-bar-cluster-eu-west-3
+    end # mock
+
+    _pure_k8s_context
+) = foo-bar-cluster-eu-west-3
+
+before_each
+@test "__pure_k8s_context: call `kubectl config current-context`" (
+    function kubectl; echo (status function) $argv > /tmp/called; end # spy
+
+    _pure_k8s_context
+    _has_called "kubectl config current-context"
+) $status -eq $SUCCESS

--- a/tests/_pure_k8s_context.test.fish
+++ b/tests/_pure_k8s_context.test.fish
@@ -10,7 +10,7 @@ end
 
 
 before_each
-@test "__pure_k8s_context: return context" (
+@test "_pure_k8s_context: return context" (
     function kubectl
         echo foo-bar-cluster-eu-west-3
     end # mock
@@ -19,7 +19,7 @@ before_each
 ) = foo-bar-cluster-eu-west-3
 
 before_each
-@test "__pure_k8s_context: call `kubectl config current-context`" (
+@test "_pure_k8s_context: call `kubectl config current-context`" (
     function kubectl; echo (status function) $argv > /tmp/called; end # spy
 
     _pure_k8s_context

--- a/tests/_pure_k8s_namespace.test.fish
+++ b/tests/_pure_k8s_namespace.test.fish
@@ -1,4 +1,5 @@
 source (dirname (status filename))/fixtures/constants.fish
+source (dirname (status filename))/mocks/mocks.fish
 source (dirname (status filename))/../functions/_pure_k8s_namespace.fish
 @echo (_print_filename (status filename))
 
@@ -11,9 +12,7 @@ end
 
 before_each
 @test "_pure_k8s_namespace: return context" (
-    function kubectl
-        echo my-namespace
-    end # mock
+    _mock kubectl
 
     _pure_k8s_namespace
 ) = my-namespace

--- a/tests/_pure_k8s_namespace.test.fish
+++ b/tests/_pure_k8s_namespace.test.fish
@@ -1,0 +1,27 @@
+source (dirname (status filename))/fixtures/constants.fish
+source (dirname (status filename))/../functions/_pure_k8s_namespace.fish
+@echo (_print_filename (status filename))
+
+
+function before_each
+    functions --erase head
+    _cleanup_calls
+end
+
+
+before_each
+@test "_pure_k8s_namespace: return context" (
+    function kubectl
+        echo my-namespace
+    end # mock
+
+    _pure_k8s_namespace
+) = my-namespace
+
+before_each
+@test "_pure_k8s_namespace: call `kubectl config view…`" (
+    function kubectl; echo (status function) $argv > /tmp/called; end # spy
+
+    _pure_k8s_namespace
+    _has_called "kubectl config view --minify --output jsonpath={..namespace}"
+) $status -eq $SUCCESS

--- a/tests/_pure_prompt_k8s.test.fish
+++ b/tests/_pure_prompt_k8s.test.fish
@@ -1,0 +1,38 @@
+source (dirname (status filename))/fixtures/constants.fish
+source (dirname (status filename))/mocks/mocks.fish
+source (dirname (status filename))/../functions/_pure_prompt_k8s.fish
+source (dirname (status filename))/../functions/_pure_k8s_context.fish
+source (dirname (status filename))/../functions/_pure_k8s_namespace.fish
+source (dirname (status filename))/../functions/_pure_check_availability.fish
+@echo (_print_filename (status filename))
+
+function before_each
+    _purge_configs
+    _disable_colors
+end
+
+function teardown
+    _clean_all_mocks
+end
+
+
+@test "_pure_prompt_k8s: ensure default behaviour has no error" (
+    _pure_prompt_k8s
+) $status -eq $SUCCESS
+
+
+@test "_pure_prompt_k8s: ensure default behaviour print nothing" (
+    echo (_pure_prompt_k8s)
+) = $EMPTY
+
+
+before_each
+@test "_pure_prompt_k8s: print kubernetes context and namespace" (
+    set --universal pure_enable_k8s true
+    set --universal pure_symbol_k8s_prefix "☸"
+    _mock kubectl
+
+    _pure_prompt_k8s
+) = '☸ my-context/my-namespace'
+
+teardown

--- a/tests/fixtures/constants.fish
+++ b/tests/fixtures/constants.fish
@@ -9,7 +9,7 @@ set --global PURE_CONFIG_VERSION_REGEX '(?<=pure_version )(?<value>[^\s#]+)'
 set --global PURE_VERSION_NUMBER_REGEX '(\d+.\d+.\d+)$'
 
 function _purge_configs --description "Erase all existing pure configurations, to avoid unwanted side-effect"
-    if test "$USER" = 'nemo'
+    if test "$USER" = nemo
         for variable in (set --names | string match --regex --entire '^pure_')
             set --erase --local $variable
             set --erase --global $variable
@@ -19,11 +19,13 @@ function _purge_configs --description "Erase all existing pure configurations, t
 end
 
 function _disable_colors --description "Set all color to empty value, to avoid unwanted side-effect"
-    if test "$USER" = 'nemo'
+    if test "$USER" = nemo
         for color_config in (set --names | string match --regex --entire '^pure_color_')
             set --universal $color_config $EMPTY
         end
-        function _pure_set_color; echo; end
+        function _pure_set_color
+            echo
+        end
     end
 end
 

--- a/tests/fixtures/constants.fish
+++ b/tests/fixtures/constants.fish
@@ -37,7 +37,7 @@ function _has_called \
 
     if test -r /tmp/called
         grep -c -q "$spy" /tmp/called \
-        || echo 'DEBUG: '(status function)': '(cat /tmp/called) # check spy was called
+            || printf "DEBUG: %s: received: `%s` expected: `%s`\n\n" (status function) (cat /tmp/called) $spy # check spy was called
     else
         return $FAILURE
     end

--- a/tests/fixtures/constants.fish
+++ b/tests/fixtures/constants.fish
@@ -31,6 +31,12 @@ function _print_filename --argument-names filename
     echo (set_color cyan)$filename(set_color normal)
 end
 
+function _cleanup_calls
+    if test -r /tmp/called
+        rm /tmp/called
+    end
+end
+
 function _has_called \
     --description "check spy method XYZ write to the /tmp/called file when called" \
     --argument-names spy # name of the method

--- a/tests/mocks/kubectl.mock.fish
+++ b/tests/mocks/kubectl.mock.fish
@@ -1,0 +1,17 @@
+function kubectl \
+    --description 'kubectl mock for test' \
+    --argument-names \
+    topcommand \
+    subcommand
+
+    if test $topcommand = config
+        if test $subcommand = current-context
+            echo my-context
+        end
+        if test $subcommand = view
+            echo my-namespace
+        end
+    else
+        echo "unknown command"
+    end
+end # mock

--- a/tests/mocks/mocks.fish
+++ b/tests/mocks/mocks.fish
@@ -1,0 +1,31 @@
+function _mock \
+    --description "Invoke a mock function" \
+    --argument-names \
+    function_name
+
+    set mock_filepath (dirname (status filename))/$function_name.mock.fish
+    if test -e $mock_filepath
+        source (dirname (status filename))/$function_name.mock.fish
+        set --global --append __mocks $function_name
+    end
+end
+
+
+function _clean_mock \
+    --description "Clean a mock function" \
+    --argument-names \
+    function_name
+
+    functions --erase $function_name
+end
+
+function _clean_all_mocks \
+    --description "Clean all mock function"
+    set --local new_mocks
+    for mock in $__mocks
+        if functions --query $mock
+            functions --erase $mock
+        end
+    end
+    set --global __mocks
+end


### PR DESCRIPTION
fixes: #322
related: #291

---

## Specs

### Required addition to config

```fish
_pure_set_default pure_enable_k8s true
_pure_set_default pure_symbol_k8s "☸️"
```

### Resources

There are several prompts that offer k8s support, we can get inspired by them:

- [aluxian/fish-kube-prompt](https://github.com/aluxian/fish-kube-prompt), see [functions/__kube_prompt.fish](https://github.com/aluxian/fish-kube-prompt/blob/master/functions/__kube_prompt.fish)
- [jonmosco/kube-ps1](https://github.com/jonmosco/kube-ps1), see [kube-ps1.sh](https://github.com/jonmosco/kube-ps1/blob/master/kube-ps1.sh)
- [Ladicle/fish-kubectl-prompt](https://github.com/Ladicle/fish-kubectl-prompt) see [functions/fish_right_prompt.fish](https://github.com/Ladicle/fish-kubectl-prompt/blob/master/functions/fish_right_prompt.fish)

### Checks

* [x] documentation is up-to-date
* [x] tests have been written
	* [x] feature is tested
	* [x] config are tested
* [x] feature flag is present
* [x] customizable prefix is available
* [x] feature is implemented

### Preview (might change)

Currently part of main prompt
![image](https://github.com/pure-fish/pure/assets/1212392/f7e37246-2c1b-4aee-a84f-7b5ade3875ea)

Warning message when `kubectl` is missing

[pure-k8s-feature.webm](https://github.com/pure-fish/pure/assets/1212392/a81bdc2f-8a18-401c-bff0-cb727f98aba7)

### Test pre-release (unstable)

```fish
fisher install pure-fish/pure@feat/add-kubernetes-k8s-support-322
set --universal pure_enable_k8s true
```