### PR TITLE
fix/tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Specify fish version to use during build
 # docker build -t <image> --build-arg FISH_VERSION=<version>
 ARG FISH_VERSION
-FROM purefish/docker-fish:${FISH_VERSION}
+FROM purefish/docker-fish:${FISH_VERSION} AS fish-only
 
 # Redeclare ARG so its value is available after FROM (cf. https://github.com/moby/moby/issues/34129#issuecomment-417609075)
 ARG FISH_VERSION
@@ -19,16 +19,20 @@ RUN apk add \
     shadow \
     vim
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+# hadolint ignore=DL3004
 RUN echo '%wheel ALL=(ALL) ALL' > /etc/sudoers.d/wheel \
     && usermod -g wheel nemo \
     && echo "nemo:123" | sudo chpasswd
 
 USER nemo
+WORKDIR /home/nemo/.config/fish/
+
+FROM fish-only AS with-pure
 # Copy source code
 COPY --chown=nemo:nemo ./conf.d/* /home/nemo/.config/fish/conf.d/
 COPY --chown=nemo:nemo ./functions/* /home/nemo/.config/fish/functions/
 COPY --chown=nemo:nemo ./tests/* /home/nemo/.config/fish/tests/
-WORKDIR /home/nemo/.config/fish/
 
 ENTRYPOINT ["fish", "-c"]
 CMD ["fishtape tests/*.test.fish"]

--- a/conf.d/_pure_init.fish
+++ b/conf.d/_pure_init.fish
@@ -8,6 +8,23 @@ set --global _pure_fresh_session true
 functions --query _pure_prompt_new_line
 
 function _pure_uninstall --on-event pure_uninstall
+    rm $__fish_config_dir/conf.d/pure.fish
+
+    # backup fish_prompt and fish_title to default
+    cp $__fish_config_dir/functions/fish_prompt{,.pure-backup}.fish
+    cp $__fish_config_dir/functions/fish_title{,.pure-backup}.fish
+
+    # erase existing fish_prompt and fish_title to default
+    functions --erase fish_prompt
+    functions --erase fish_title
+    # restore fish_prompt and fish_title to default
+    cp {$__fish_data_dir,$__fish_config_dir}/functions/fish_prompt.fish
+    cp {$__fish_data_dir,$__fish_config_dir}/functions/fish_title.fish
+
+    # refresh fish_prompt and fish_title definitions
+    source $__fish_data_dir/functions/fish_prompt.fish
+    source $__fish_data_dir/functions/fish_title.fish
+
     # erase _pure* variables
     set --names \
         | string replace --filter --regex '(^_?pure)' 'set --erase $1' \
@@ -20,6 +37,4 @@ function _pure_uninstall --on-event pure_uninstall
     for file in $__fish_config_dir/{functions,conf.d}/_pure_*
         rm $file
     end
-    # restore fish_prompt to default
-    cp {$__fish_data_dir,$__fish_config_dir}/functions/fish_prompt.fish
 end

--- a/makefile
+++ b/makefile
@@ -18,6 +18,7 @@ build-pure-on:
 	docker build \
 		--quiet \
 		--file ./Dockerfile \
+		--target fish-only \
 		--build-arg FISH_VERSION=${FISH_VERSION} \
 		--tag=pure-on-fish-${FISH_VERSION} \
 		./

--- a/tests/_pure.test.fish
+++ b/tests/_pure.test.fish
@@ -3,11 +3,11 @@ source (dirname (status filename))/../functions/_pure_set_default.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
 end
-setup
+before_all
 
 @test "configure: pure_version" (
     set --erase pure_version

--- a/tests/_pure_check_for_new_release.test.fish
+++ b/tests/_pure_check_for_new_release.test.fish
@@ -3,10 +3,11 @@ source (dirname (status filename))/../functions/_pure_check_for_new_release.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
-end; setup
+end
+before_all
 
 @test "_pure_check_for_new_release: is disabled" (
     set --universal pure_check_for_new_release false

--- a/tests/_pure_detect_container_by_cgroup_method.test.fish
+++ b/tests/_pure_detect_container_by_cgroup_method.test.fish
@@ -3,7 +3,7 @@ source (dirname (status filename))/../functions/_pure_detect_container_by_cgroup
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
 
@@ -11,9 +11,9 @@ function setup
     set --global namespace (dirname $cgroup_namespace)
     mkdir -p $namespace; and touch $cgroup_namespace
 end
-setup
+before_all
 
-function teardown
+function after_all
     rm -rf \
         $namespace \
         $cgroup_namespace
@@ -21,8 +21,8 @@ function teardown
     set --erase namespace
 end
 
-if test (uname -s) = "Linux"
-@test "_pure_detect_container_by_cgroup_method: false for host OS" (
+if test (uname -s) = Linux
+    @test "_pure_detect_container_by_cgroup_method: false for host OS" (
     echo "1:name=systemd:/init.scope" > $cgroup_namespace
     set --global container $EMPTY
 
@@ -30,28 +30,28 @@ if test (uname -s) = "Linux"
 ) $status -eq $FAILURE
 end
 
-if test (uname -s) = "Linux"
-@test "_pure_detect_container_by_cgroup_method: true for Docker's container" (
+if test (uname -s) = Linux
+    @test "_pure_detect_container_by_cgroup_method: true for Docker's container" (
     echo "1:name=systemd:/docker/54c541…af18c609c" > $cgroup_namespace
 
     _pure_detect_container_by_cgroup_method $cgroup_namespace
 ) $status -eq $SUCCESS
 end
 
-if test (uname -s) = "Linux"
-@test "_pure_detect_container_by_cgroup_method: true for LXC/LXD's container (using namespace detail)" (
+if test (uname -s) = Linux
+    @test "_pure_detect_container_by_cgroup_method: true for LXC/LXD's container (using namespace detail)" (
     echo "1:name=systemd:/lxc/54c541…af18c609c" > $cgroup_namespace
 
     _pure_detect_container_by_cgroup_method $cgroup_namespace
 ) $status -eq $SUCCESS
 end
 
-if test (uname -s) = "Linux"
-@test "_pure_detect_container_by_cgroup_method: true for LXC/LXD's container (using environment variable)" (
+if test (uname -s) = Linux
+    @test "_pure_detect_container_by_cgroup_method: true for LXC/LXD's container (using environment variable)" (
     set --global container 'lxc'
 
     _pure_detect_container_by_cgroup_method $cgroup_namespace
 ) $status -eq $SUCCESS
 end
 
-teardown
+after_all

--- a/tests/_pure_detect_container_by_pid_method.test.fish
+++ b/tests/_pure_detect_container_by_pid_method.test.fish
@@ -1,4 +1,5 @@
 source (dirname (status filename))/fixtures/constants.fish
+source (dirname (status filename))/mocks/mocks.fish
 source (dirname (status filename))/../functions/_pure_detect_container_by_pid_method.fish
 @echo (_print_filename (status filename))
 
@@ -26,7 +27,7 @@ end
 before_each
 @test "_pure_detect_container_by_pid_method: ignored when /proc/*/scheg is missing" (
     rm -rf $proc_sched
-    function head; echo (status function) > /tmp/called; end # spy
+    _spy head
 
     _pure_detect_container_by_pid_method $proc_sched
     _has_called head
@@ -36,7 +37,7 @@ before_each
 before_each
 @test "_pure_detect_container_by_pid_method: when /proc/*/scheg exists" (
     _create_proc_sched_file $proc_sched
-    function head; echo (status function) > /tmp/called; end # spy
+    _spy head
 
     _pure_detect_container_by_pid_method $proc_sched
     _has_called head

--- a/tests/_pure_detect_container_by_pid_method.test.fish
+++ b/tests/_pure_detect_container_by_pid_method.test.fish
@@ -11,12 +11,13 @@ end
 before_all
 
 function after_all
-    functions --erase uname
+    set --erase proc_sched
 end
 
-set proc_sched /tmp/1/sched
 function before_each
+    set --global proc_sched /tmp/1/sched
     functions --erase head
+    _cleanup_calls
 end
 
 function _create_proc_sched_file --argument-names proc_sched
@@ -73,5 +74,3 @@ if test (uname -s) = Linux
         _pure_detect_container_by_pid_method $proc_sched
     ) $status -eq $SUCCESS
 end
-
-# after_all

--- a/tests/_pure_detect_container_by_pid_method.test.fish
+++ b/tests/_pure_detect_container_by_pid_method.test.fish
@@ -17,7 +17,7 @@ end
 function before_each
     set --global proc_sched /tmp/1/sched
     functions --erase head
-    _cleanup_calls
+    _cleanup_spy_calls
 end
 
 function _create_proc_sched_file --argument-names proc_sched

--- a/tests/_pure_detect_container_by_pid_method.test.fish
+++ b/tests/_pure_detect_container_by_pid_method.test.fish
@@ -3,13 +3,13 @@ source (dirname (status filename))/../functions/_pure_detect_container_by_pid_me
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
 end
-setup
+before_all
 
-function teardown
+function after_all
     functions --erase uname
 end
 
@@ -73,4 +73,4 @@ if test (uname -s) = Linux
     ) $status -eq $SUCCESS
 end
 
-# teardown
+# after_all

--- a/tests/_pure_format_time.test.fish
+++ b/tests/_pure_format_time.test.fish
@@ -3,10 +3,11 @@ source (dirname (status filename))/../functions/_pure_format_time.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
-end; setup
+end
+before_all
 
 set --local threshold 0 # in seconds
 
@@ -25,7 +26,7 @@ set --local threshold 0 # in seconds
 @test "_pure_format_time: format 1s to human" (
     set --local millisecond 1000 # express as milliseconds
     _pure_format_time (math "1*$millisecond") $threshold
-) = '1s'
+) = 1s
 
 @test "_pure_format_time: format 1050ms to human (show milliseconds)" (
     set --local milliseconds 1053 # express as milliseconds
@@ -35,32 +36,32 @@ set --local threshold 0 # in seconds
 @test "_pure_format_time: format 60s as a minutes to human" (
     set --local millisecond 1000 # express as milliseconds
     _pure_format_time (math "60*$millisecond") $threshold
-) = '1m'
+) = 1m
 
 @test "_pure_format_time: format 59 minutes to human" (
     set --local minute 60000 # express as milliseconds
     _pure_format_time (math "59*$minute") $threshold
-) = '59m'
+) = 59m
 
 @test "_pure_format_time: format 60min as an hour to human" (
     set --local minute 60000 # express as milliseconds
     _pure_format_time (math "60*$minute") $threshold
-) = '1h'
+) = 1h
 
 @test "_pure_format_time: format 23 hours to human" (
     set --local hour 3600000 # express as milliseconds
     _pure_format_time (math "23*$hour") $threshold
-) = '23h'
+) = 23h
 
 @test "_pure_format_time: format 24 hours as a day to human" (
     set --local hour 3600000 # express as milliseconds
     _pure_format_time (math "24*$hour") $threshold
-) = '1d'
+) = 1d
 
 @test "_pure_format_time: format days to human" (
     set --local day 86400000 # express as milliseconds
     _pure_format_time (math "100*$day") $threshold
-) = '100d'
+) = 100d
 
 @test "_pure_format_time: format complex duration to human" (
     _pure_format_time 123456789 $threshold

--- a/tests/_pure_get_prompt_symbol.test.fish
+++ b/tests/_pure_get_prompt_symbol.test.fish
@@ -3,16 +3,17 @@ source (dirname (status filename))/../functions/_pure_get_prompt_symbol.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
     set --universal pure_symbol_prompt '❯'
     set --universal pure_symbol_reverse_prompt '❮'
-end; setup
+end
+before_all
 
-function teardown
+function after_all
     set fish_key_bindings fish_default_key_bindings
-    set fish_bind_mode 'default'
+    set fish_bind_mode default
 end
 
 
@@ -71,4 +72,4 @@ end
 ) = '❮'
 
 
-teardown
+after_all

--- a/tests/_pure_init.test.fish
+++ b/tests/_pure_init.test.fish
@@ -2,19 +2,20 @@ source (dirname (status filename))/fixtures/constants.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
-end; setup
+end
+before_all
 
 
-@test "init: _pure_fresh_session"  (
+@test "init: _pure_fresh_session" (
     set --erase _pure_fresh_session
     source (dirname (status filename))/../conf.d/_pure_init.fish
     echo $_pure_fresh_session
 ) = true
 
-@test "init: VIRTUAL_ENV_DISABLE_PROMPT"  (
+@test "init: VIRTUAL_ENV_DISABLE_PROMPT" (
     set --erase VIRTUAL_ENV_DISABLE_PROMPT
     source (dirname (status filename))/../conf.d/_pure_init.fish
     echo $VIRTUAL_ENV_DISABLE_PROMPT

--- a/tests/_pure_is_inside_container.test.fish
+++ b/tests/_pure_is_inside_container.test.fish
@@ -6,7 +6,7 @@ source (dirname (status filename))/../functions/_pure_detect_container_by_cgroup
 
 
 # echo "SYSTEM CONTAINER: $container"
-function setup
+function before_all
     _purge_configs
     _disable_colors
 
@@ -14,7 +14,7 @@ function setup
     set --global namespace (dirname $cgroup_namespace)
     mkdir -p $namespace; and touch $cgroup_namespace
 end
-setup
+before_all
 
 function cleanup_detection_methods
     functions --erase _pure_detect_container_by_pid_method
@@ -26,7 +26,7 @@ function cleanup_spy
     functions --erase uname
 end
 
-function teardown
+function after_all
     rm -rf \
         $namespace \
         $cgroup_namespace
@@ -95,4 +95,4 @@ if test (uname -s) = Linux
 end
 
 
-teardown
+after_all

--- a/tests/_pure_is_single_line_prompt.test.fish
+++ b/tests/_pure_is_single_line_prompt.test.fish
@@ -3,10 +3,11 @@ source (dirname (status filename))/../functions/_pure_is_single_line_prompt.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
-end; setup
+end
+before_all
 
 @test "_pure_is_single_line_prompt: fail when unset" (
     set --erase pure_enable_single_line_prompt

--- a/tests/_pure_k8s_context.test.fish
+++ b/tests/_pure_k8s_context.test.fish
@@ -6,7 +6,7 @@ source (dirname (status filename))/../functions/_pure_k8s_context.fish
 
 function before_each
     functions --erase head
-    _cleanup_calls
+    _cleanup_spy_calls
 end
 
 

--- a/tests/_pure_k8s_namespace.test.fish
+++ b/tests/_pure_k8s_namespace.test.fish
@@ -6,7 +6,7 @@ source (dirname (status filename))/../functions/_pure_k8s_namespace.fish
 
 function before_each
     functions --erase head
-    _cleanup_calls
+    _cleanup_spy_calls
 end
 
 

--- a/tests/_pure_parse_directory.test.fish
+++ b/tests/_pure_parse_directory.test.fish
@@ -3,12 +3,17 @@ source (dirname (status filename))/../functions/_pure_parse_directory.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
-end; setup
+    set --universal pure_shorten_prompt_current_directory_length 0
+end
 
+function after_all
+    set --erase pure_shorten_prompt_current_directory_length
+end
 
+before_all
 @test "_pure_parse_directory: returns current directory" (
     mkdir -p /tmp/current/directory/
     cd /tmp/current/directory/
@@ -34,4 +39,6 @@ end; setup
     cd /tmp/current/directory/
 
     _pure_parse_directory
-) = "/tm/cu/directory"
+) = /tm/cu/directory
+
+after_all

--- a/tests/_pure_parse_git_branch.test.fish
+++ b/tests/_pure_parse_git_branch.test.fish
@@ -3,7 +3,7 @@ source (dirname (status filename))/../functions/_pure_parse_git_branch.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
     mkdir -p /tmp/test_pure_parse_git_branch # prevent conflict between parallel test files
@@ -12,9 +12,10 @@ function setup
     git init --quiet
     git config --global user.email "you@example.com"
     git config --global user.name "Your Name"
-end; setup
+end
+before_all
 
-function teardown
+function after_all
     rm -rf /tmp/test_pure_parse_git_branch
 end
 
@@ -23,7 +24,7 @@ end
     cd /tmp/test_pure_parse_git_branch
 
     _pure_parse_git_branch
-) = 'master'
+) = master
 
 
 @test "_pure_parse_git_branch: returns number of commits behind current branch" (
@@ -41,4 +42,4 @@ end
 ) = 'master~1'
 
 
-teardown
+after_all

--- a/tests/_pure_place_iterm2_prompt_mark.test.fish
+++ b/tests/_pure_place_iterm2_prompt_mark.test.fish
@@ -3,10 +3,11 @@ source (dirname (status filename))/../functions/_pure_place_iterm2_prompt_mark.f
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
-end; setup
+end
+before_all
 
 
 @test "_pure_place_iterm2_prompt_mark: no iterm2 prompt mark when NOT in iTerm" (
@@ -17,4 +18,4 @@ end; setup
     function iterm2_prompt_mark; echo 'iterm2-mark'; end
 
     echo (_pure_place_iterm2_prompt_mark)
-) = 'iterm2-mark'
+) = iterm2-mark

--- a/tests/_pure_prefix_root_prompt.test.fish
+++ b/tests/_pure_prefix_root_prompt.test.fish
@@ -3,11 +3,12 @@ source (dirname (status filename))/../functions/_pure_prefix_root_prompt.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
     set --universal pure_symbol_prefix_root_prompt '#'
-end; setup
+end
+before_all
 
 @test "_pure_prefix_root_prompt: is empty for unprivileged user" (
     set --universal pure_show_prefix_root_prompt true

--- a/tests/_pure_print_prompt.test.fish
+++ b/tests/_pure_print_prompt.test.fish
@@ -4,10 +4,11 @@ source (dirname (status filename))/../functions/_pure_string_width.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
-end; setup
+end
+before_all
 
 @test "_pure_print_prompt: returns nothing when no argument provided" (
     _pure_print_prompt

--- a/tests/_pure_print_prompt_rows.test.fish
+++ b/tests/_pure_print_prompt_rows.test.fish
@@ -4,13 +4,16 @@ source (dirname (status filename))/../functions/_pure_print_prompt_rows.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
-    function _pure_prompt_first_line; echo $EMPTY; end
-end; setup
+    function _pure_prompt_first_line
+        echo $EMPTY
+    end
+end
+before_all
 
-function teardown
+function after_all
     functions --erase _pure_prompt_first_line
 end
 
@@ -26,4 +29,4 @@ end
 ) = 0
 
 
-teardown
+after_all

--- a/tests/_pure_prompt.test.fish
+++ b/tests/_pure_prompt.test.fish
@@ -21,7 +21,7 @@ function before_each
     set --universal pure_symbol_prompt '>' # using default ❯ break following tests
 end
 
-function teardown
+function after_all
     functions --erase id
 end
 
@@ -68,4 +68,4 @@ end
 ) = "$SPACE>"
 
 
-teardown
+after_all

--- a/tests/_pure_prompt_beginning.test.fish
+++ b/tests/_pure_prompt_beginning.test.fish
@@ -3,10 +3,11 @@ source (dirname (status filename))/../functions/_pure_prompt_beginning.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
-end; setup
+end
+before_all
 
 
 @test "_pure_prompt_beginning: clear line before printing prompt" (

--- a/tests/_pure_prompt_command_duration.test.fish
+++ b/tests/_pure_prompt_command_duration.test.fish
@@ -4,10 +4,11 @@ source (dirname (status filename))/../functions/_pure_prompt_command_duration.fi
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
-end; setup
+end
+before_all
 
 
 @test "_pure_prompt_command_duration: hide command duration when it's zero" (
@@ -21,7 +22,7 @@ end; setup
     set --universal pure_threshold_command_duration 5 # in seconds
 
     _pure_prompt_command_duration
-) = '6s'
+) = 6s
 
 @test "_pure_prompt_command_duration: displays command duration with ms when non-zero" (
     set CMD_DURATION 6053 # in milliseconds

--- a/tests/_pure_prompt_current_folder.test.fish
+++ b/tests/_pure_prompt_current_folder.test.fish
@@ -7,7 +7,8 @@ source (dirname (status filename))/../functions/_pure_parse_directory.fish
 function setup
     _purge_configs
     _disable_colors
-end; setup
+end
+setup
 
 
 @test "_pure_prompt_current_folder: fails if no argument given" (
@@ -17,6 +18,7 @@ end; setup
 @test "_pure_prompt_current_folder: returns current folder" (
     set COLUMNS 20
     set current_prompt_width 10
+    set pure_shorten_prompt_current_directory_length 0
     mkdir -p /tmp/.pure;
     and cd /tmp/.pure
 

--- a/tests/_pure_prompt_current_folder.test.fish
+++ b/tests/_pure_prompt_current_folder.test.fish
@@ -4,12 +4,17 @@ source (dirname (status filename))/../functions/_pure_parse_directory.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
+    set --universal pure_shorten_prompt_current_directory_length 0
 end
-setup
 
+function after_all
+    set --erase pure_shorten_prompt_current_directory_length
+end
+
+before_all
 
 @test "_pure_prompt_current_folder: fails if no argument given" (
     _pure_prompt_current_folder
@@ -24,3 +29,5 @@ setup
 
     string length (_pure_prompt_current_folder "$current_prompt_width")
 ) = 8
+
+after_all

--- a/tests/_pure_prompt_ending.test.fish
+++ b/tests/_pure_prompt_ending.test.fish
@@ -3,10 +3,11 @@ source (dirname (status filename))/../functions/_pure_prompt_ending.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
-end; setup
+end
+before_all
 
 
 @test "_pure_prompt_ending: reset color to normal" (

--- a/tests/_pure_prompt_first_line.test.fish
+++ b/tests/_pure_prompt_first_line.test.fish
@@ -3,7 +3,7 @@ source (dirname (status filename))/../functions/_pure_prompt_first_line.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
 
@@ -12,17 +12,32 @@ function setup
     git init --quiet
     set SSH_CONNECTION 127.0.0.1 56422 127.0.0.1 22
 
-    function _pure_print_prompt; string join ' ' $argv; end
-    function _pure_prompt_ssh; echo 'user@hostname'; end
-    function _pure_prompt_container; end
-    function _pure_prompt_k8s; end
-    function _pure_prompt_git; echo 'master'; end
-    function _pure_prompt_command_duration; echo '1s'; end
-    function _pure_string_width; echo 15; end
-    function _pure_prompt_current_folder; pwd; end
-end; setup
+    function _pure_print_prompt
+        string join ' ' $argv
+    end
+    function _pure_prompt_ssh
+        echo 'user@hostname'
+    end
+    function _pure_prompt_container
+    end
+    function _pure_prompt_k8s
+    end
+    function _pure_prompt_git
+        echo master
+    end
+    function _pure_prompt_command_duration
+        echo 1s
+    end
+    function _pure_string_width
+        echo 15
+    end
+    function _pure_prompt_current_folder
+        pwd
+    end
+end
+before_all
 
-function teardown
+function after_all
     functions --erase _pure_print_prompt
     functions --erase _pure_prompt_ssh
     functions --erase _pure_prompt_container
@@ -50,8 +65,8 @@ end
     rm -rf /tmp/test
 ) = 'user@hostname /tmp/test master 1s'
 
-if test "$USER" = 'nemo'
-@test "_pure_prompt_first_line: displays 'nemo@hostname' when inside container" (
+if test "$USER" = nemo
+    @test "_pure_prompt_first_line: displays 'nemo@hostname' when inside container" (
     function _pure_prompt_container; echo $USER'@hostname'; end
 
     string match --quiet --entire --regex "nemo@[\w]+" (_pure_prompt_first_line)
@@ -64,4 +79,4 @@ end
     string match --quiet --entire --regex "context/namespace" (_pure_prompt_first_line)
 ) $status -eq $SUCCESS
 
-teardown
+after_all

--- a/tests/_pure_prompt_first_line.test.fish
+++ b/tests/_pure_prompt_first_line.test.fish
@@ -15,6 +15,7 @@ function setup
     function _pure_print_prompt; string join ' ' $argv; end
     function _pure_prompt_ssh; echo 'user@hostname'; end
     function _pure_prompt_container; end
+    function _pure_prompt_k8s; end
     function _pure_prompt_git; echo 'master'; end
     function _pure_prompt_command_duration; echo '1s'; end
     function _pure_string_width; echo 15; end
@@ -25,6 +26,7 @@ function teardown
     functions --erase _pure_print_prompt
     functions --erase _pure_prompt_ssh
     functions --erase _pure_prompt_container
+    functions --erase _pure_prompt_k8s
     functions --erase _pure_prompt_git
     functions --erase _pure_prompt_command_duration
     functions --erase _pure_string_width
@@ -52,9 +54,14 @@ if test "$USER" = 'nemo'
 @test "_pure_prompt_first_line: displays 'nemo@hostname' when inside container" (
     function _pure_prompt_container; echo $USER'@hostname'; end
 
-    string match --quiet --entire --regex "nemo@[\w]+" (_pure_prompt_container)
+    string match --quiet --entire --regex "nemo@[\w]+" (_pure_prompt_first_line)
 ) $status -eq $SUCCESS
 end
 
+@test "_pure_prompt_first_line: show kubernetes context and namespace" (
+    function _pure_prompt_k8s; echo 'context/namespace'; end
+
+    string match --quiet --entire --regex "context/namespace" (_pure_prompt_first_line)
+) $status -eq $SUCCESS
 
 teardown

--- a/tests/_pure_prompt_git.test.fish
+++ b/tests/_pure_prompt_git.test.fish
@@ -7,15 +7,16 @@ source (dirname (status filename))/../functions/_pure_prompt_git_stash.fish
 @echo (_print_filename (status filename))
 
 
-function setup
-    mkdir -p /tmp/test_pure_prompt_git  # prevent conflict between parallel test files
+function before_all
+    mkdir -p /tmp/test_pure_prompt_git # prevent conflict between parallel test files
     and cd /tmp/test_pure_prompt_git
 
     _purge_configs
     _disable_colors
-end; setup
+end
+before_all
 
-function teardown
+function after_all
     rm -rf /tmp/test_pure_prompt_git
 end
 
@@ -50,7 +51,7 @@ end
     set --universal pure_enable_git true
 
     _pure_prompt_git
-) = 'master'
+) = master
 
 @test "_pure_prompt_git: activates on dirty repository" (
     git init --quiet
@@ -83,4 +84,4 @@ end
 ) $status -eq $SUCCESS
 
 
-teardown
+after_all

--- a/tests/_pure_prompt_git_branch.test.fish
+++ b/tests/_pure_prompt_git_branch.test.fish
@@ -4,8 +4,8 @@ source (dirname (status filename))/../functions/_pure_parse_git_branch.fish
 @echo (_print_filename (status filename))
 
 
-function setup
-    mkdir -p /tmp/test_pure_prompt_git_branch  # prevent conflict between parallel test files
+function before_all
+    mkdir -p /tmp/test_pure_prompt_git_branch # prevent conflict between parallel test files
     and cd /tmp/test_pure_prompt_git_branch
 
     git init --quiet
@@ -14,16 +14,17 @@ function setup
 
     _purge_configs
     _disable_colors
-end; setup
+end
+before_all
 
-function teardown
+function after_all
     rm -rf /tmp/test_pure_prompt_git_branch
 end
 
 
 @test "_pure_prompt_git_branch: show branch name" (
     _pure_prompt_git_branch
-) = 'master'
+) = master
 
 @test "_pure_prompt_git_branch: colorize branch name" (
     source (dirname (status filename))/../functions/_pure_set_color.fish # enable colors
@@ -32,4 +33,4 @@ end
 ) = (set_color grey)'master'
 
 
-teardown
+after_all

--- a/tests/_pure_prompt_git_dirty.test.fish
+++ b/tests/_pure_prompt_git_dirty.test.fish
@@ -3,7 +3,7 @@ source (dirname (status filename))/../functions/_pure_prompt_git_dirty.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     mkdir -p /tmp/pure_pure_prompt_git_dirty # prevent conflict between parallel test files
     and cd /tmp/pure_pure_prompt_git_dirty
 
@@ -13,9 +13,10 @@ function setup
 
     _purge_configs
     _disable_colors
-end; setup
+end
+before_all
 
-function teardown
+function after_all
     rm -rf /tmp/pure_pure_prompt_git_dirty
 end
 
@@ -46,4 +47,4 @@ end
 ) = (set_color brblack)'*'
 
 
-teardown
+after_all

--- a/tests/_pure_prompt_jobs.test.fish
+++ b/tests/_pure_prompt_jobs.test.fish
@@ -3,14 +3,15 @@ source (dirname (status filename))/../functions/_pure_prompt_jobs.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
 
     set --global JOB_DURATION 1.5
-end; setup
+end
+before_all
 
-function teardown
+function after_all
     set --erase --global JOB_DURATION
 end
 
@@ -37,4 +38,4 @@ end
 ) = (set_color grey)'[1]'
 
 
-teardown
+after_all

--- a/tests/_pure_prompt_k8s.test.fish
+++ b/tests/_pure_prompt_k8s.test.fish
@@ -11,7 +11,7 @@ function before_each
     _disable_colors
 end
 
-function teardown
+function after_all
     _clean_all_mocks
 end
 
@@ -35,4 +35,4 @@ before_each
     _pure_prompt_k8s
 ) = '☸ my-context/my-namespace'
 
-teardown
+after_all

--- a/tests/_pure_prompt_new_line.test.fish
+++ b/tests/_pure_prompt_new_line.test.fish
@@ -4,10 +4,11 @@ source (dirname (status filename))/../functions/_pure_prompt_new_line.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
-end; setup
+end
+before_all
 
 
 @test "_pure_prompt_new_line: print prompt with newline for existing session" (

--- a/tests/_pure_prompt_symbol.test.fish
+++ b/tests/_pure_prompt_symbol.test.fish
@@ -4,12 +4,13 @@ source (dirname (status filename))/../functions/_pure_get_prompt_symbol.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
 
-    set --universal pure_symbol_prompt '>'  # using default ❯ break following tests
-end; setup
+    set --universal pure_symbol_prompt '>' # using default ❯ break following tests
+end
+before_all
 
 
 @test "_pure_prompt_symbol: colorizes prompt in green when last command succeed" (

--- a/tests/_pure_prompt_system_time.test.fish
+++ b/tests/_pure_prompt_system_time.test.fish
@@ -3,10 +3,11 @@ source (dirname (status filename))/../functions/_pure_prompt_system_time.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
-end; setup
+end
+before_all
 
 
 @test "_pure_prompt_system_time: no system time when disable" (

--- a/tests/_pure_prompt_vimode.test.fish
+++ b/tests/_pure_prompt_vimode.test.fish
@@ -9,7 +9,7 @@ function before_each
     _disable_colors
 end
 
-function teardown
+function after_all
     set fish_key_bindings fish_default_key_bindings
 end
 
@@ -32,7 +32,7 @@ if fish_version_below 3.3.0
     set --universal pure_reverse_prompt_symbol_in_vimode false
 
     _pure_prompt_vimode
-    teardown
+    after_all
 ) = (set_color --bold --background red white)'[N] '(set_color normal)' '
 end
 
@@ -44,6 +44,6 @@ if fish_version_at_least 3.3.0
     set --universal pure_reverse_prompt_symbol_in_vimode false
 
     _pure_prompt_vimode
-    teardown
+    after_all
 ) = (set_color --bold red)'[N] '(set_color normal)' ' # see value from https://github.com/fish-shell/fish-shell/blob/master/share/functions/fish_default_mode_prompt.fish
 end

--- a/tests/_pure_set_default.test.fish
+++ b/tests/_pure_set_default.test.fish
@@ -3,12 +3,13 @@ source (dirname (status filename))/../functions/_pure_set_default.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
-end; setup
+end
+before_all
 
-function teardown
+function after_all
     set --erase --universal pure_fake_config
     set --erase --global pure_fake_config
 end
@@ -18,35 +19,35 @@ end
     _pure_set_default pure_fake_config 'default'
 
     echo $pure_fake_config
-) = 'default'
+) = default
 
 @test "_pure_set_default: ignore value when variable already declared on UNIVERSAL scope" (
     set --universal pure_fake_config 'default'
 
     _pure_set_default pure_fake_config 'new'
     echo $pure_fake_config
-) = 'default'
+) = default
 
 @test "_pure_set_default: set value when declared on UNIVERSAL scope but is an empty string (i.e. prevent empty colors)" (
     set --universal pure_fake_config $EMPTY
 
     _pure_set_default pure_fake_config 'new'
     echo $pure_fake_config
-) = 'new'
+) = new
 
 @test "_pure_set_default: ignore value when variable already declared on GLOBAL scope" (
     set --universal pure_fake_config 'default'
 
     _pure_set_default pure_fake_config 'new'
     echo $pure_fake_config
-) = 'default'
+) = default
 
 @test "_pure_set_default: ignore value when declared on GLOBAL scope but is an empty string (i.e. prevent empty colors)" (
     set --global pure_fake_config $EMPTY
 
     _pure_set_default pure_fake_config 'new'
     echo $pure_fake_config
-) != 'new' # ⚠️ Universal variable is shadowed by the global variable of the same name.
+) != new # ⚠️ Universal variable is shadowed by the global variable of the same name.
 
 
-teardown
+after_all

--- a/tests/_pure_string_width.test.fish
+++ b/tests/_pure_string_width.test.fish
@@ -3,10 +3,11 @@ source (dirname (status filename))/../functions/_pure_string_width.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
-end; setup
+end
+before_all
 
 
 @test "_pure_string_width: measure empty string" (

--- a/tests/_pure_user_at_host.test.fish
+++ b/tests/_pure_user_at_host.test.fish
@@ -3,10 +3,11 @@ source (dirname (status filename))/../functions/_pure_user_at_host.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     _purge_configs
     _disable_colors
-end; setup
+end
+before_all
 
 
 @test "_pure_user_at_host: standard user" (

--- a/tests/fish_title.test.fish
+++ b/tests/fish_title.test.fish
@@ -3,11 +3,12 @@ source (dirname (status filename))/../functions/fish_title.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     mkdir -p /tmp/current/directory/
     cd /tmp/current/directory/
-
-end; setup
+    set --universal pure_shorten_window_title_current_directory_length 0
+end
+before_all
 
 @test "fish_title: contains current directory and previous command" (
     set --universal pure_symbol_title_bar_separator '-'

--- a/tests/fixtures/config.mock.fish
+++ b/tests/fixtures/config.mock.fish
@@ -1,6 +1,6 @@
 # FOR TESTS-ONLY
-_pure_set_default pure_color_ssh_hostname "value"
-_pure_set_default pure_color_ssh_separator "value"
-_pure_set_default pure_color_ssh_user_normal "value"
-_pure_set_default pure_color_ssh_user_root "value"
+_pure_set_default pure_color_hostname "value"
+_pure_set_default pure_color_at_sign "value"
+_pure_set_default pure_color_username_normal "value"
+_pure_set_default pure_color_username_root "value"
 # FOR TESTS-ONLY

--- a/tests/fixtures/constants.fish
+++ b/tests/fixtures/constants.fish
@@ -32,21 +32,3 @@ end
 function _print_filename --argument-names filename
     echo (set_color cyan)$filename(set_color normal)
 end
-
-function _cleanup_calls
-    if test -r /tmp/called
-        rm /tmp/called
-    end
-end
-
-function _has_called \
-    --description "check spy method XYZ write to the /tmp/called file when called" \
-    --argument-names spy # name of the method
-
-    if test -r /tmp/called
-        grep -c -q "$spy" /tmp/called \
-            || printf "DEBUG: %s: received: `%s` expected: `%s`\n\n" (status function) (cat /tmp/called) $spy # check spy was called
-    else
-        return $FAILURE
-    end
-end

--- a/tests/migration-to-4.0.0.test.fish
+++ b/tests/migration-to-4.0.0.test.fish
@@ -2,19 +2,19 @@ source (dirname (status filename))/fixtures/constants.fish
 @echo (_print_filename (status filename))
 
 
-function setup
+function before_all
     # tests/fixtures/ permissions are o=rwx /!\
     cp tests/fixtures/{config.mock.fish,config.fish}
 end
-setup
+before_all
 
-function teardown
+function after_all
     rm tests/fixtures/config.fish
 end
 
 
 @test "migrate all variables" (
-    set file_to_migrate (dirname (status filename))/fixtures/config.mock.fish  # created during 'setup'
+    set file_to_migrate (dirname (status filename))/fixtures/config.mock.fish  # created during 'before_all'
 
     fish (dirname (status filename))/../tools/migration-to-4.0.0.fish $file_to_migrate 2>&1 >/dev/null
 
@@ -22,4 +22,4 @@ end
 ) $status -eq $SUCCESS
 
 
-teardown
+after_all

--- a/tests/mocks/mocks.fish
+++ b/tests/mocks/mocks.fish
@@ -1,7 +1,7 @@
 function _mock \
     --description "Invoke a mock function" \
     --argument-names \
-    function_name
+    function_name # name of the method to mock
 
     set mock_filepath (dirname (status filename))/$function_name.mock.fish
     if test -e $mock_filepath
@@ -28,4 +28,14 @@ function _clean_all_mocks \
         end
     end
     set --global __mocks
+end
+
+function _spy \
+    --description "Create a spy around method" \
+    --argument-names \
+    function_name # name of the method to spy
+
+    function $function_name
+        echo (status function) >/tmp/called
+    end # spy
 end

--- a/tests/mocks/mocks.fish
+++ b/tests/mocks/mocks.fish
@@ -1,5 +1,5 @@
 function _mock \
-    --description "Invoke a mock function" \
+    --description "Invoke a mock function located in tests/mocks/" \
     --argument-names \
     function_name # name of the method to mock
 

--- a/tests/mocks/mocks.fish
+++ b/tests/mocks/mocks.fish
@@ -39,3 +39,22 @@ function _spy \
         echo (status function) >/tmp/called
     end # spy
 end
+
+
+function _cleanup_spy_calls
+    if test -r /tmp/called
+        rm /tmp/called
+    end
+end
+
+function _has_called \
+    --description "check spy method XYZ write to the /tmp/called file when called" \
+    --argument-names spy # name of the method
+
+    if test -r /tmp/called
+        grep -c -q "$spy" /tmp/called \
+            || printf "DEBUG: %s: received: `%s` expected: `%s`\n\n" (status function) (cat /tmp/called) $spy # check spy was called
+    else
+        return $FAILURE
+    end
+end


### PR DESCRIPTION
- test: set a value for pure_shorten_prompt_current_directory_length
- test: check _pure_prompt_first_line show kubernetes context and namespace
- test: set pure_shorten_prompt_current_directory_length to valid value
- chore: add stage to Dockerfile
- fix: improve uninstallation script
- test: set pure_shorten_window_title_current_directory_length default
- chore(test): rename hooks setup->before_all, teardown->after_all
- test: create a `_spy` function to log calls in /tmp/called
- docs: update _mock description
- test: clean up spy call after each test
- refactor(spy): move _has_called and _cleanup_call to mocks/mocks.fish
