### PR TITLE
feat(python): add feature flag to control virtualenv behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Fully **customizable** (colors, symbols and features):
 - check for new release on start 🏴 ;
 - Display _username_ and _hostname_ when in an `SSH` session ;
 - Display command _duration_ when longer than `5` seconds ;
-- Display `Python` _virtualenv_ when activated ;
+- Display `Python` _virtualenv_ when activated 🏴 ;
 - Display `VI` mode and custom symbol for non-insert mode 🏴 ;
 - Display `kubernetes` context and namespace
 - Display container indicator (e.g. `docker`, `podman`, `LXC`/`LXD`) 🏴
@@ -74,20 +74,21 @@ set --universal pure_color_system_time pure_color_mute
 
 ### Prompt Symbol
 
-| Option                                 | Default | Description                                                         |
-| :------------------------------------- | :------ | :------------------------------------------------------------------ |
-| **`pure_symbol_container_prefix`**     |         | Prefix when being inside a container ([to customize][to-set])       |
-| **`pure_symbol_git_dirty`**            | `*`     | Repository is Dirty (uncommitted/untracked changes).                |
-| **`pure_symbol_git_stash`**            | `≡`     | Repository git stash status.                                        |
-| **`pure_symbol_git_unpulled_commits`** | `⇣`     | Branch is behind upstream (commits to pull).                        |
-| **`pure_symbol_git_unpushed_commits`** | `⇡`     | Branch is ahead upstream (commits to push).                         |
-| **`pure_symbol_k8s_prefix`**           | `☸`     | Prefix when being connected to Kubernetes/K8s                       |
-| **`pure_symbol_prefix_root_prompt`**   | `#`     | Prefix prompt when logged in as `root`.                             |
-| **`pure_symbol_prefix_root_prompt`**   | `#`     | Prefix when being root user                                         |
-| **`pure_symbol_prompt`**               | `❯`     | Prompt symbol.                                                      |
-| **`pure_symbol_reverse_prompt`**       | `❮`     | VI non-insert mode symbol.                                          |
-| **`pure_symbol_ssh_prefix`**           |         | Prefix when being connected to SSH session ([to customize][to-set]) |
-| **`pure_symbol_title_bar_separator`**  | `-`     | Separator in terminal's windows title.                              |
+| Option                                 | Default | Description                                                                  |
+| :------------------------------------- | :------ | :--------------------------------------------------------------------------- |
+| **`pure_symbol_container_prefix`**     |         | Prefix when being inside a container ([to customize][to-set])                |
+| **`pure_symbol_git_dirty`**            | `*`     | Repository is Dirty (uncommitted/untracked changes).                         |
+| **`pure_symbol_git_stash`**            | `≡`     | Repository git stash status.                                                 |
+| **`pure_symbol_git_unpulled_commits`** | `⇣`     | Branch is behind upstream (commits to pull).                                 |
+| **`pure_symbol_git_unpushed_commits`** | `⇡`     | Branch is ahead upstream (commits to push).                                  |
+| **`pure_symbol_k8s_prefix`**           | `☸`     | Prefix when being connected to Kubernetes/K8s                                |
+| **`pure_symbol_prefix_root_prompt`**   | `#`     | Prefix prompt when logged in as `root`.                                      |
+| **`pure_symbol_prefix_root_prompt`**   | `#`     | Prefix when being root user                                                  |
+| **`pure_symbol_prompt`**               | `❯`     | Prompt symbol.                                                               |
+| **`pure_symbol_reverse_prompt`**       | `❮`     | VI non-insert mode symbol.                                                   |
+| **`pure_symbol_ssh_prefix`**           |         | Prefix when being connected to SSH session (default: [undefined][to-set])    |
+| **`pure_symbol_title_bar_separator`**  | `-`     | Separator in terminal's windows title.                                       |
+| **`pure_symbol_virtualenv_prefix`**    |         | Prefix when a Python virtual env is activated (default: [undefined][to-set]) |
 
 > :information_source: Need [safer `git` symbols](https://github.com/sindresorhus/pure/wiki/Customizations,-hacks-and-tweaks#safer-symbols)?
 
@@ -101,6 +102,7 @@ set --universal pure_color_system_time pure_color_mute
 | **`pure_enable_git`**                                    | `true`  | Show info about Git repository.                                                                                                                                     |
 | **`pure_enable_k8s`**                                    | `false` | `true`: shows `kubernetes` context and namespace.                                                                                                                   |
 | **`pure_enable_single_line_prompt`**                     | `false` | `true`: Compact prompt as a single line                                                                                                                             |
+| **`pure_enable_virtualenv`**                             | `true`  | Show virtual env name (based on `VIRTUAL_ENV` or `CONDA_DEFAULT_ENV`).                                                                                              |
 | **`pure_reverse_prompt_symbol_in_vimode`**               | `true`  | `true`: `❮` indicate a non-insert mode.<br/>`false`: indicate vi mode with `[I]`, `[N]`, `[V]`.                                                                     |
 | **`pure_separate_prompt_on_error`**                      | `false` | Show last command [exit code as a separate character][exit-code].                                                                                                   |
 | **`pure_shorten_prompt_current_directory_length`**       | `0`     | Shorten every prompt path component but the last to X characters (0 do not shorten)                                                                                 |

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -48,7 +48,8 @@ _pure_set_default pure_show_system_time false
 _pure_set_default pure_color_system_time pure_color_mute
 
 #  env for Python
-# _pure_set_default pure_enable_virtualenv true
+_pure_set_default pure_enable_virtualenv true
+_pure_set_default pure_symbol_virtualenv_prefix "" # 🐍
 _pure_set_default pure_color_virtualenv pure_color_mute
 
 # Print current working directory at the beginning of prompt

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -48,6 +48,7 @@ _pure_set_default pure_show_system_time false
 _pure_set_default pure_color_system_time pure_color_mute
 
 #  env for Python
+# _pure_set_default pure_enable_virtualenv true
 _pure_set_default pure_color_virtualenv pure_color_mute
 
 # Print current working directory at the beginning of prompt

--- a/functions/_pure_prompt_virtualenv.fish
+++ b/functions/_pure_prompt_virtualenv.fish
@@ -1,4 +1,9 @@
 function _pure_prompt_virtualenv --description "Display virtualenv directory"
+
+    if set --query pure_enable_virtualenv;
+        and test "$pure_enable_virtualenv" = true
+        # todo
+    end
     if test -n "$VIRTUAL_ENV"
         set --local virtualenv (basename "$VIRTUAL_ENV")
         set --local virtualenv_color (_pure_set_color $pure_color_virtualenv)

--- a/functions/_pure_prompt_virtualenv.fish
+++ b/functions/_pure_prompt_virtualenv.fish
@@ -2,17 +2,17 @@ function _pure_prompt_virtualenv --description "Display virtualenv directory"
 
     if set --query pure_enable_virtualenv;
         and test "$pure_enable_virtualenv" = true
-        # todo
-    end
-    if test -n "$VIRTUAL_ENV"
-        set --local virtualenv (basename "$VIRTUAL_ENV")
-        set --local virtualenv_color (_pure_set_color $pure_color_virtualenv)
 
-        echo "$virtualenv_color$virtualenv"
-    else if test -n "$CONDA_DEFAULT_ENV"
-        set --local virtualenv (basename "$CONDA_DEFAULT_ENV")
+        set --local virtualenv ''
         set --local virtualenv_color (_pure_set_color $pure_color_virtualenv)
+        if test -n "$VIRTUAL_ENV"
+            set virtualenv (basename "$VIRTUAL_ENV")
+        else if test -n "$CONDA_DEFAULT_ENV"
+            set virtualenv (basename "$CONDA_DEFAULT_ENV")
+        end
 
-        echo "$virtualenv_color$virtualenv"
+        if test -n $virtualenv
+            echo "$pure_symbol_virtualenv_prefix$virtualenv_color$virtualenv"
+        end
     end
 end

--- a/tests/_pure.test.fish
+++ b/tests/_pure.test.fish
@@ -219,6 +219,12 @@ before_all
     echo $pure_color_system_time
 ) = pure_color_mute
 
+@test "configure: pure_enable_virtualenv" (
+    set --erase pure_enable_virtualenv
+    source (dirname (status filename))/../conf.d/pure.fish
+    echo $pure_enable_virtualenv
+) = true
+
 @test "configure: pure_color_virtualenv" (
     set --erase pure_color_virtualenv
     source (dirname (status filename))/../conf.d/pure.fish
@@ -302,7 +308,6 @@ before_all
     source (dirname (status filename))/../conf.d/pure.fish
     echo $pure_symbol_ssh_prefix
 ) = ""
-
 
 @test "configure: pure_enable_k8s" (
     set --erase pure_enable_k8s

--- a/tests/_pure.test.fish
+++ b/tests/_pure.test.fish
@@ -225,6 +225,12 @@ before_all
     echo $pure_enable_virtualenv
 ) = true
 
+@test "configure: pure_symbol_virtualenv_prefix" (
+    set --erase pure_symbol_virtualenv_prefix
+    source (dirname (status filename))/../conf.d/pure.fish
+    echo $pure_symbol_virtualenv_prefix
+) = $EMPTY
+
 @test "configure: pure_color_virtualenv" (
     set --erase pure_color_virtualenv
     source (dirname (status filename))/../conf.d/pure.fish

--- a/tests/_pure_prompt_virtualenv.test.fish
+++ b/tests/_pure_prompt_virtualenv.test.fish
@@ -13,9 +13,18 @@ function before_each
     set --erase --global CONDA_DEFAULT_ENV
 end
 
-
 @test "_pure_prompt_virtualenv: hide virtualenv prompt when not activated" (
     before_each
+    set --universal pure_enable_virtualenv false
+    set --erase VIRTUAL_ENV
+
+    _pure_prompt_virtualenv
+) $status -eq $SUCCESS
+
+
+@test "_pure_prompt_virtualenv: hide virtualenv prompt when env variable is absent" (
+    before_each
+    set --universal pure_enable_virtualenv true
     set --erase VIRTUAL_ENV
 
     _pure_prompt_virtualenv
@@ -23,6 +32,7 @@ end
 
 @test "_pure_prompt_virtualenv: displays virtualenv directory prompt" (
     before_each
+    set --universal pure_enable_virtualenv true
     set VIRTUAL_ENV /home/test/fake/project/
 
     _pure_prompt_virtualenv
@@ -30,6 +40,7 @@ end
 
 @test "_pure_prompt_virtualenv: hides Conda virtualenv prompt when not activated" (
     before_each
+    set --universal pure_enable_virtualenv true
     set --erase CONDA_DEFAULT_ENV
 
     _pure_prompt_virtualenv
@@ -37,6 +48,7 @@ end
 
 @test "_pure_prompt_virtualenv: displays Conda virtualenv directory prompt" (
     before_each
+    set --universal pure_enable_virtualenv true
     set CONDA_DEFAULT_ENV /home/test/fake/project/
 
     _pure_prompt_virtualenv

--- a/tests/_pure_prompt_virtualenv.test.fish
+++ b/tests/_pure_prompt_virtualenv.test.fish
@@ -3,18 +3,15 @@ source (dirname (status filename))/../functions/_pure_prompt_virtualenv.fish
 @echo (_print_filename (status filename))
 
 
-function before_all
-    _disable_colors
-end
-before_all
-
 function before_each
+    _purge_configs
+    _disable_colors
     set --erase --global VIRTUAL_ENV
     set --erase --global CONDA_DEFAULT_ENV
 end
 
+before_each
 @test "_pure_prompt_virtualenv: hide virtualenv prompt when not activated" (
-    before_each
     set --universal pure_enable_virtualenv false
     set --erase VIRTUAL_ENV
 
@@ -22,34 +19,53 @@ end
 ) $status -eq $SUCCESS
 
 
+before_each
 @test "_pure_prompt_virtualenv: hide virtualenv prompt when env variable is absent" (
-    before_each
     set --universal pure_enable_virtualenv true
     set --erase VIRTUAL_ENV
 
     _pure_prompt_virtualenv
 ) $status -eq $SUCCESS
 
+before_each
 @test "_pure_prompt_virtualenv: displays virtualenv directory prompt" (
-    before_each
     set --universal pure_enable_virtualenv true
     set VIRTUAL_ENV /home/test/fake/project/
 
     _pure_prompt_virtualenv
 ) = project
 
+before_each
+@test "_pure_prompt_virtualenv: displays virtualenv symbol prefix" (
+    set --universal pure_enable_virtualenv true
+    set --universal pure_symbol_virtualenv_prefix "🐍"
+    set VIRTUAL_ENV /home/test/fake/project/
+
+    _pure_prompt_virtualenv
+) = "🐍project"
+
+
+before_each
 @test "_pure_prompt_virtualenv: hides Conda virtualenv prompt when not activated" (
-    before_each
     set --universal pure_enable_virtualenv true
     set --erase CONDA_DEFAULT_ENV
 
     _pure_prompt_virtualenv
 ) $status -eq $SUCCESS
 
+before_each
 @test "_pure_prompt_virtualenv: displays Conda virtualenv directory prompt" (
-    before_each
     set --universal pure_enable_virtualenv true
     set CONDA_DEFAULT_ENV /home/test/fake/project/
 
     _pure_prompt_virtualenv
 ) = project
+
+before_each
+@test "_pure_prompt_virtualenv: displays virtualenv symbol prefix" (
+    set --universal pure_enable_virtualenv true
+    set --universal pure_symbol_virtualenv_prefix "🐍"
+    set CONDA_DEFAULT_ENV /home/test/fake/project/
+
+    _pure_prompt_virtualenv
+) = "🐍project"


### PR DESCRIPTION
fixes #274, fixes #291

### Documentation

For legacy reason, this flag is set to `true` in order to preserve existing user dev experience.

#### Usage

```shell
❯ set --universal pure_enable_virtualenv true
```

## Acceptance Checks

* [x] documentation is up-to-date:
  * [x] [features list][features] ;
  * [x] [Prompt Symbol][symbol] ;
  * [x] [🔌 Features' Flags][feature-flag] ;
* [x] feature flag is present in `conf.d/pure.fish` ;
* [x] symbol is present in `conf.d/pure.fish` ;
* [x] tests are passing (I can help you :hugs: ):
  * [x] config are tested (cf. [tests/_pure.test.fish][config-test]) ;
  * [x] feature is covered ;
* [x] customization is available ;
* [x] feature is implemented.

[config-test]: tests/_pure.test.fish
[contribute]: /pure-fish/pure/#1-contribute
[contributing]: CONTRIBUTING.md
[feature-flag]: /pure-fish/pure/#-features-flags
[symbol]: /pure-fish/pure/#prompt-symbol
[features]: /pure-fish/pure/#features
