### PR TITLE
fix/missing blank line between prompts 293

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,10 @@ COPY --chown=nemo:nemo ./    /home/nemo/.config/fish/pure/
 
 # create an image with pure installed as prompt
 FROM with-pure-source AS with-pure-installed
-RUN cp ./pure/ ./
+RUN echo 'Symlink dev files' \
+    && ln -nfs "$(pwd)"/completions/*.fish ../completions/ \
+    && ln -nfs "$(pwd)"/conf.d/*.fish ../conf.d/ \
+    && ln -nfs "$(pwd)"/functions/*.fish ../functions/
 
 ENTRYPOINT ["fish", "-c"]
 CMD ["fishtape tests/*.test.fish"]

--- a/functions/_pure_print_prompt.fish
+++ b/functions/_pure_print_prompt.fish
@@ -1,6 +1,5 @@
 function _pure_print_prompt \
-    --description 'Concatenate parts single prompt string' \
-
+    --description 'Concatenate parts single prompt string'
     set --local prompt
 
     for prompt_part in $argv

--- a/functions/_pure_prompt_beginning.fish
+++ b/functions/_pure_prompt_beginning.fish
@@ -1,5 +1,6 @@
-function _pure_prompt_beginning
-    # Clear existing line content
+function _pure_prompt_beginning \
+    --description 'Clear existing line content'
+
     set --local clear_line "\r\033[K"
 
     echo $clear_line

--- a/functions/_pure_prompt_new_line.fish
+++ b/functions/_pure_prompt_new_line.fish
@@ -7,5 +7,5 @@ function _pure_prompt_new_line \
         set new_line "\n"
     end
 
-    echo -e -n "$new_line"
+    echo -e -n (_pure_prompt_beginning)"$new_line"
 end

--- a/functions/_pure_prompt_new_line.fish
+++ b/functions/_pure_prompt_new_line.fish
@@ -2,7 +2,7 @@ function _pure_prompt_new_line \
     --description "Do not add a line break to a brand new session" \
     --on-event fish_prompt
 
-    set --local new_line
+    set --local new_line ''
     if not _pure_is_single_line_prompt; and test "$_pure_fresh_session" = false
         set new_line "\n"
     end

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -2,7 +2,6 @@
 function fish_prompt
     set --local exit_code $status # save previous exit code
 
-    echo -e -n (_pure_prompt_beginning)  # init prompt context (clear current line, etc.)
     _pure_print_prompt_rows # manage default vs. compact prompt
     _pure_place_iterm2_prompt_mark # place iTerm shell integration mark
     echo -e -n (_pure_prompt $exit_code) # print prompt

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -1,12 +1,12 @@
 # a called to `_pure_prompt_new_line` is triggered by an event
 function fish_prompt
-    set --local exit_code $status  # save previous exit code
+    set --local exit_code $status # save previous exit code
 
     echo -e -n (_pure_prompt_beginning)  # init prompt context (clear current line, etc.)
     _pure_print_prompt_rows # manage default vs. compact prompt
     _pure_place_iterm2_prompt_mark # place iTerm shell integration mark
-    echo -e -n (_pure_prompt $exit_code)  # print prompt
-    echo -e (_pure_prompt_ending)  # reset colors and end prompt
+    echo -e -n (_pure_prompt $exit_code) # print prompt
+    echo -e (_pure_prompt_ending) # reset colors and end prompt
 
     set _pure_fresh_session false
 end

--- a/makefile
+++ b/makefile
@@ -53,8 +53,9 @@ test-pure-on: build-with-pure-source
 build-with-pure-source:
 	$(MAKE) build-pure-on FISH_VERSION=${FISH_VERSION} STAGE=with-pure-source
 
-.PHONY: build-with-pure-installed
-build-with-pure-installed:
+.PHONY: dev-with-pure-installed
+dev-with-pure-installed:
 	$(MAKE) build-pure-on FISH_VERSION=${FISH_VERSION} STAGE=with-pure-installed
+	$(MAKE) dev-pure-on FISH_VERSION=${FISH_VERSION} STAGE=with-pure-installed
 
 

--- a/tests/_pure_prompt_new_line.test.fish
+++ b/tests/_pure_prompt_new_line.test.fish
@@ -1,5 +1,7 @@
 source (dirname (status filename))/fixtures/constants.fish
+source (dirname (status filename))/mocks/mocks.fish
 source (dirname (status filename))/../functions/_pure_is_single_line_prompt.fish
+source (dirname (status filename))/../functions/_pure_prompt_beginning.fish
 source (dirname (status filename))/../functions/_pure_prompt_new_line.fish
 @echo (_print_filename (status filename))
 
@@ -9,6 +11,11 @@ function before_all
     _disable_colors
 end
 before_all
+
+function before_each
+    source (dirname (status filename))/../functions/_pure_prompt_beginning.fish # restore function
+    _cleanup_spy_calls
+end
 
 
 @test "_pure_prompt_new_line: print prompt with newline for existing session" (
@@ -29,3 +36,32 @@ before_all
 
     _pure_prompt_new_line | wc -l
 ) = $NONE
+
+before_each
+@test "_pure_prompt_new_line: print prompt with newline for existing session" (
+    set _pure_fresh_session false
+    functions --erase _pure_prompt_beginning
+    _spy _pure_prompt_beginning
+
+    _pure_prompt_new_line
+
+    _has_called _pure_prompt_beginning
+) $status -eq $SUCCESS
+
+
+before_each
+@test "_pure_prompt_new_line: clean prompt and print prompt with newline for existing session" (
+    set _pure_fresh_session false
+    set --universal pure_enable_single_line_prompt false
+
+    _pure_prompt_new_line | string collect --no-trim-newlines
+) = \r\e'[K'\n
+
+
+before_each
+@test "_pure_prompt_new_line: clean prompt and print prompt with newline for existing session" (
+    set _pure_fresh_session false
+    set --universal pure_enable_single_line_prompt true
+
+    _pure_prompt_new_line | string collect --no-trim-newlines
+) = \r\e"[K"

--- a/tests/fish_prompt.test.fish
+++ b/tests/fish_prompt.test.fish
@@ -9,9 +9,6 @@ function before_all
     _purge_configs
     _disable_colors
 
-    function _pure_prompt_beginning --description "stub function"
-        echo '['
-    end
     function _pure_prompt_first_line --description "stub function"
         echo '/path/ git duration'
     end
@@ -27,7 +24,6 @@ end
 
 function after_all --description "erasing stubs"
     functions --erase \
-        _pure_prompt_beginning \
         _pure_prompt_first_line \
         _pure_place_iterm2_prompt_mark \
         _pure_prompt \
@@ -44,8 +40,8 @@ before_all
 @test "fish_prompt: print segments" (
     set --universal pure_enable_single_line_prompt true
 
-    fish_prompt
-) = '[/path/ git duration ❯]'
+    fish_prompt | string collect --no-trim-newlines
+) = '/path/ git duration ❯]'\n
 
 
 @test "fish_prompt: change with exit status" (
@@ -53,7 +49,7 @@ before_all
     function _pure_prompt; echo ' fail❯'; end
 
     fish_prompt
-) = '[/path/ git duration fail❯]'
+) = '/path/ git duration fail❯]'
 
 @test "fish_prompt: disable _pure_fresh_session" (
     set --global _pure_fresh_session  # so we can see its update


### PR DESCRIPTION
related: #293 

---

### What?

Calling `_pure_prompt_beginning` was **happening after** `_pure_prompt_new_line` thus erasing the eventual new line character. I moved `_pure_prompt_beginning` call from `fish_prompt.fish` to  `_pure_prompt_new_line.fish` so it happens before adding the newline character.


# Test pre-release (unstable)

```
fisher remove pure-fish/pure
fisher install pure-fish/pure@fix/missing-blank-line-between-prompts-293
```