### PR TITLE
refactor k8s support

### DIFF
--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -97,6 +97,6 @@ _pure_set_default pure_symbol_ssh_prefix "" # suggestion: 'ssh:/' or '🔗🔐�
 # Display Kubernetes/k8s context and namespace
 _pure_set_default pure_enable_k8s false
 _pure_set_default pure_symbol_k8s_prefix "☸" # ☸️
-_pure_set_default pure_color_k8s_symbol pure_color_dark
+_pure_set_default pure_color_k8s_prefix pure_color_dark
 _pure_set_default pure_color_k8s_context pure_color_success
 _pure_set_default pure_color_k8s_namespace pure_color_primary

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -97,5 +97,6 @@ _pure_set_default pure_symbol_ssh_prefix "" # suggestion: 'ssh:/' or '🔗🔐�
 # Display Kubernetes/k8s context and namespace
 _pure_set_default pure_enable_k8s false
 _pure_set_default pure_symbol_k8s_prefix "☸" # ☸️
+_pure_set_default pure_color_k8s_symbol pure_color_dark
 _pure_set_default pure_color_k8s_context pure_color_success
 _pure_set_default pure_color_k8s_namespace pure_color_primary

--- a/functions/_pure_k8s_context.fish
+++ b/functions/_pure_k8s_context.fish
@@ -1,3 +1,3 @@
 function _pure_k8s_context
-    kubectl config current-context
+    kubectl config current-context 2>/dev/null
 end

--- a/functions/_pure_k8s_namespace.fish
+++ b/functions/_pure_k8s_namespace.fish
@@ -1,3 +1,3 @@
 function _pure_k8s_namespace
-    kubectl config view --minify --output 'jsonpath={..namespace}'
+    kubectl config view --minify --output 'jsonpath={..namespace}' 2>/dev/null
 end

--- a/functions/_pure_prompt_k8s.fish
+++ b/functions/_pure_prompt_k8s.fish
@@ -2,7 +2,7 @@ function _pure_prompt_k8s
     if set --query pure_enable_k8s;
         and test "$pure_enable_k8s" = true;
         and _pure_check_availability pure_enable_k8s kubectl
-        and test -n "$(_pure_k8s_context)"
+        and test -n (_pure_k8s_context) # todo: use $(cmd) syntax when Fish 3.3.1 is dropped
 
         set --local symbol (_pure_set_color $pure_color_k8s_symbol)$pure_symbol_k8s_prefix
         set --local context (_pure_set_color $pure_color_k8s_context)(_pure_k8s_context)

--- a/functions/_pure_prompt_k8s.fish
+++ b/functions/_pure_prompt_k8s.fish
@@ -4,12 +4,12 @@ function _pure_prompt_k8s
         and _pure_check_availability pure_enable_k8s kubectl
         and test -n "$(_pure_k8s_context)"
 
-        set -l symbol (_pure_set_color $pure_color_k8s_symbol)$pure_symbol_k8s_prefix
-        set -l context (_pure_set_color $pure_color_k8s_context)(_pure_k8s_context)
-        set -l namespace (_pure_set_color $pure_color_k8s_namespace)(_pure_k8s_namespace)
+        set --local symbol (_pure_set_color $pure_color_k8s_symbol)$pure_symbol_k8s_prefix
+        set --local context (_pure_set_color $pure_color_k8s_context)(_pure_k8s_context)
+        set --local namespace (_pure_set_color $pure_color_k8s_namespace)(_pure_k8s_namespace)
 
         if test -n "$namespace"
-            set -l namespace (_pure_set_color $pure_color_k8s_namespace)default
+            set --local namespace (_pure_set_color $pure_color_k8s_namespace)default
         end
 
         echo "$symbol $context/$namespace"

--- a/functions/_pure_prompt_k8s.fish
+++ b/functions/_pure_prompt_k8s.fish
@@ -3,8 +3,10 @@ function _pure_prompt_k8s
         and test "$pure_enable_k8s" = true;
         and _pure_check_availability pure_enable_k8s kubectl
 
+        set -l symbol (_pure_set_color $pure_color_k8s_symbol)$pure_symbol_k8s_prefix
         set -l context (_pure_set_color $pure_color_k8s_context)(_pure_k8s_context)
         set -l namespace (_pure_set_color $pure_color_k8s_namespace)(_pure_k8s_namespace)
-        echo "$pure_symbol_k8s_prefix $context/$namespace"
+
+        echo "$symbol $context/$namespace"
     end
 end

--- a/functions/_pure_prompt_k8s.fish
+++ b/functions/_pure_prompt_k8s.fish
@@ -2,6 +2,7 @@ function _pure_prompt_k8s
     if set --query pure_enable_k8s;
         and test "$pure_enable_k8s" = true;
         and _pure_check_availability pure_enable_k8s kubectl
+        and test -n "$(_pure_k8s_context)"
 
         set -l symbol (_pure_set_color $pure_color_k8s_symbol)$pure_symbol_k8s_prefix
         set -l context (_pure_set_color $pure_color_k8s_context)(_pure_k8s_context)

--- a/functions/_pure_prompt_k8s.fish
+++ b/functions/_pure_prompt_k8s.fish
@@ -4,7 +4,7 @@ function _pure_prompt_k8s
         and _pure_check_availability pure_enable_k8s kubectl
         and test -n (_pure_k8s_context) # todo: use $(cmd) syntax when Fish 3.3.1 is dropped
 
-        set --local symbol (_pure_set_color $pure_color_k8s_symbol)$pure_symbol_k8s_prefix
+        set --local symbol (_pure_set_color $pure_color_k8s_prefix)$pure_symbol_k8s_prefix
         set --local context (_pure_set_color $pure_color_k8s_context)(_pure_k8s_context)
         set --local namespace (_pure_set_color $pure_color_k8s_namespace)(_pure_k8s_namespace)
 

--- a/functions/_pure_prompt_k8s.fish
+++ b/functions/_pure_prompt_k8s.fish
@@ -8,6 +8,10 @@ function _pure_prompt_k8s
         set -l context (_pure_set_color $pure_color_k8s_context)(_pure_k8s_context)
         set -l namespace (_pure_set_color $pure_color_k8s_namespace)(_pure_k8s_namespace)
 
+        if test -n "$namespace"
+            set -l namespace (_pure_set_color $pure_color_k8s_namespace)default
+        end
+
         echo "$symbol $context/$namespace"
     end
 end

--- a/tests/_pure.test.fish
+++ b/tests/_pure.test.fish
@@ -327,10 +327,10 @@ before_all
     echo $pure_symbol_k8s_prefix
 ) = "☸"
 
-@test "configure: pure_color_k8s_symbol" (
-    set --erase pure_color_k8s_symbol
+@test "configure: pure_color_k8s_prefix" (
+    set --erase pure_color_k8s_prefix
     source (status dirname)/../conf.d/pure.fish
-    echo $pure_color_k8s_symbol
+    echo $pure_color_k8s_prefix
 ) = pure_color_dark
 
 @test "configure: pure_color_k8s_context" (

--- a/tests/_pure.test.fish
+++ b/tests/_pure.test.fish
@@ -327,6 +327,12 @@ before_all
     echo $pure_symbol_k8s_prefix
 ) = "☸"
 
+@test "configure: pure_color_k8s_symbol" (
+    set --erase pure_color_k8s_symbol
+    source (status dirname)/../conf.d/pure.fish
+    echo $pure_color_k8s_symbol
+) = pure_color_dark
+
 @test "configure: pure_color_k8s_context" (
     set --erase pure_color_k8s_context
     source (status dirname)/../conf.d/pure.fish


### PR DESCRIPTION
## How to test pre-release?

> :skull_and_crossbones: Feature **can** be unstable and break your prompt!

```shell
fisher install bobsoppe/fish-prompt-pure@improve-k8s-support
set --universal pure_enable_k8s true
set --universal pure_color_k8s_symbol cyan
```

## Specs

### New config in `conf.d/pure.fish`

```fish
_pure_set_default pure_color_k8s_symbol pure_color_dark
```

### Documentation

#### Usage

```shell
set --universal pure_enable_k8s true
```

#### Changes
- Added option to color the k8s symbol
- Added logic to show the k8s prompt when a context has been set
- Added logic to show the default k8s namespace


## Acceptance Checks

* [x] documentation is up-to-date:
  * [x] [features list][features] ;
  * [x] [Prompt Symbol][symbol] ;
  * [x] [🔌 Features' Flags][feature-flag] ;
* [x] feature flag is present in `conf.d/pure.fish` ;
* [x] symbol is present in `conf.d/pure.fish` ;
* [x] tests are passing (I can help you :hugs: ):
  * [x] config are tested (cf. [tests/_pure.test.fish][config-test]) ;
  * [x] feature is covered ;
* [x] customization is available ;
* [x] feature is implemented.

[config-test]: tests/_pure.test.fish
[contribute]: /pure-fish/pure/#1-contribute
[contributing]: CONTRIBUTING.md
[feature-flag]: /pure-fish/pure/#-features-flags
[symbol]: /pure-fish/pure/#prompt-symbol
[features]: /pure-fish/pure/#features
