### PR TITLE
fix k8s context checking

### DIFF
--- a/functions/_pure_prompt_k8s.fish
+++ b/functions/_pure_prompt_k8s.fish
@@ -3,8 +3,17 @@ function _pure_prompt_k8s
         and test "$pure_enable_k8s" = true;
         and _pure_check_availability pure_enable_k8s kubectl
 
-        set -l context (_pure_set_color $pure_color_k8s_context)(_pure_k8s_context)
-        set -l namespace (_pure_set_color $pure_color_k8s_namespace)(_pure_k8s_namespace)
-        echo "$pure_symbol_k8s_prefix $context/$namespace"
+        set --local context (_pure_set_color $pure_color_k8s_context)(_pure_k8s_context)
+
+        if test -n "$context"
+            set --local symbol (_pure_set_color $pure_color_k8s_prefix)$pure_symbol_k8s_prefix
+            set --local namespace (_pure_set_color $pure_color_k8s_namespace)(_pure_k8s_namespace)
+
+            if test -n "$namespace"
+                set --local namespace (_pure_set_color $pure_color_k8s_namespace)default
+            end
+
+            echo "$symbol $context/$namespace"
+        end
     end
 end


### PR DESCRIPTION
Fixes the check if any k8s context has been set

Bug was introduced in commit 12f9e99807b5ffdcea96a09a8687434179788541 from pull request #330 where the check was changed to support fish <= 3.3.1.