### PR TITLE
feat: truncate prompt current_directory and title to keep  last components

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Fully **customizable** (colors, symbols and features):
   - Async update when [configured with fish-async-prompt](https://github.com/pure-fish/pure/wiki/Async-git-Prompt) ;
 - Update terminal title with _current folder_ and _command_ ;
 - Detect when running in a container ;
-- Shorten _current folder_ component 🏴;
+- Shorten _current folder_ component in prompt and window title 🏴;
+- Truncate _current folder_ component in prompt and window title 🏴;
 
 🏴: Enabled or disabled via a [feature flag](#-features-flags).
 
@@ -117,6 +118,8 @@ set --universal pure_color_system_time pure_color_mute
 | **`pure_show_subsecond_command_duration`**               | `false` | Show subsecond (ex. 1.5s) in command duration.                                                                                                                      |
 | **`pure_show_system_time`**                              | `false` | `true`: shows system time before the prompt symbol (as `%H:%M:%S`).                                                                                                 |
 | **`pure_threshold_command_duration`**                    | `5`     | Show command duration when above this value (seconds).                                                                                                              |
+| **`pure_truncate_prompt_current_directory_keeps`**       | `0`    | Truncate working directory path in prompt, but keeps the last to `n` components (`0` full path in current directory)                                               |
+| **`pure_truncate_window_title_current_directory_keeps`** | `0`    | Truncate working directory path in window title, but keeps the last to `n` components (`0` full path in window title)                                         |
 
 ### 🎨 Colours
 

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -20,6 +20,7 @@ _pure_set_default pure_color_prompt_on_success pure_color_success
 # Current Working Directory
 _pure_set_default pure_color_current_directory pure_color_primary
 _pure_set_default pure_shorten_prompt_current_directory_length 0
+_pure_set_default pure_truncate_prompt_current_directory_keeps -1
 
 # Git
 _pure_set_default pure_enable_git true
@@ -75,6 +76,7 @@ _pure_set_default pure_reverse_prompt_symbol_in_vimode true
 # Title
 _pure_set_default pure_symbol_title_bar_separator -
 _pure_set_default pure_shorten_window_title_current_directory_length 0
+_pure_set_default pure_truncate_window_title_current_directory_keeps -1
 
 # Check for new release on startup
 _pure_set_default pure_check_for_new_release false

--- a/functions/_pure_is_inside_container.fish
+++ b/functions/_pure_is_inside_container.fish
@@ -11,7 +11,7 @@ function _pure_is_inside_container \
 
         set --local os_name (uname -s)
         # echo $os_name
-        if test $os_name = Linux
+        if test "$os_name" = Linux
             if _pure_detect_container_by_cgroup_method $cgroup_namespace
                 return $success
             end

--- a/functions/_pure_parse_directory.fish
+++ b/functions/_pure_parse_directory.fish
@@ -10,5 +10,14 @@ function _pure_parse_directory \
             set folder (fish_prompt_pwd_dir_length=1 prompt_pwd)
         end
     end
+
+    if test $pure_truncate_prompt_current_directory_keeps -ge 1
+        set folder (
+            string split '/' $folder \
+                | tail -n $pure_truncate_prompt_current_directory_keeps \
+                | string join '/'
+        )
+    end
+
     echo $folder
 end

--- a/functions/_pure_parse_directory.fish
+++ b/functions/_pure_parse_directory.fish
@@ -4,14 +4,14 @@ function _pure_parse_directory \
 
     set --local folder (fish_prompt_pwd_dir_length=$pure_shorten_prompt_current_directory_length prompt_pwd)
 
-    if test -n "$max_path_length";
-        if test (string length $folder) -gt $max_path_length;
+    if test -n "$max_path_length"
+        if test (string length $folder) -gt $max_path_length
             # If path exceeds maximum symbol limit, force fish path formating function to use 1 character
             set folder (fish_prompt_pwd_dir_length=1 prompt_pwd)
         end
     end
 
-    if test $pure_truncate_prompt_current_directory_keeps -ge 1
+    if test "$pure_truncate_prompt_current_directory_keeps" -ge 1
         set folder (
             string split '/' $folder \
                 | tail -n $pure_truncate_prompt_current_directory_keeps \

--- a/tests/_pure.test.fish
+++ b/tests/_pure.test.fish
@@ -344,3 +344,15 @@ before_all
     source (status dirname)/../conf.d/pure.fish
     echo $pure_color_k8s_namespace
 ) = pure_color_primary
+
+@test "configure: pure_truncate_prompt_current_directory_keeps" (
+    set --erase pure_truncate_prompt_current_directory_keeps
+    source (status dirname)/../conf.d/pure.fish
+    echo $pure_truncate_prompt_current_directory_keeps
+) = -1
+
+@test "configure: pure_truncate_window_title_current_directory_keeps" (
+    set --erase pure_truncate_window_title_current_directory_keeps
+    source (status dirname)/../conf.d/pure.fish
+    echo $pure_truncate_window_title_current_directory_keeps
+) = -1

--- a/tests/_pure_parse_directory.test.fish
+++ b/tests/_pure_parse_directory.test.fish
@@ -3,17 +3,18 @@ source (status dirname)/../functions/_pure_parse_directory.fish
 @echo (_print_filename (status filename))
 
 
-function before_all
+function before_each
     _purge_configs
     _disable_colors
     set --universal pure_shorten_prompt_current_directory_length 0
+    set --universal pure_truncate_prompt_current_directory_keeps 0
 end
 
-function after_all
+function after_each
     set --erase pure_shorten_prompt_current_directory_length
 end
 
-before_all
+before_each
 @test "_pure_parse_directory: returns current directory" (
     mkdir -p /tmp/current/directory/
     cd /tmp/current/directory/
@@ -21,6 +22,7 @@ before_all
     _pure_parse_directory
 ) = $PWD
 
+before_each
 @test '_pure_parse_directory: replaces $HOME by ~' (
     pushd $HOME
 
@@ -28,10 +30,12 @@ before_all
     popd
 ) = '~'
 
+before_each
 @test '_pure_parse_directory: shortens directory in prompt' (
     string length (_pure_parse_directory 1)
 ) -lt (string length $PWD)
 
+before_each
 @test '_pure_parse_directory: shorten current directory' (
     set --universal pure_shorten_prompt_current_directory_length 2
 
@@ -40,5 +44,36 @@ before_all
 
     _pure_parse_directory
 ) = /tm/cu/directory
+after_each
 
-after_all
+before_each
+@test '_pure_parse_directory: truncate 1, keeps only last directory name from current directory path' (
+    set --universal pure_truncate_prompt_current_directory_keeps 1
+
+    mkdir -p /tmp/current/directory/
+    cd /tmp/current/directory/
+
+    _pure_parse_directory
+) = directory
+
+before_each
+@test '_pure_parse_directory: truncate n last component from current directory path' (
+    set --universal pure_truncate_prompt_current_directory_keeps 2
+
+    mkdir -p /tmp/current/directory/
+    cd /tmp/current/directory/
+
+    _pure_parse_directory
+) = current/directory
+
+before_each
+@test '_pure_parse_directory: truncate 0, keeps full current directory path' (
+    set --universal pure_truncate_prompt_current_directory_keeps 0
+
+    mkdir -p /tmp/current/directory/
+    cd /tmp/current/directory/
+
+    _pure_parse_directory
+) = /tmp/current/directory
+
+

--- a/tests/_pure_prompt_current_folder.test.fish
+++ b/tests/_pure_prompt_current_folder.test.fish
@@ -8,6 +8,7 @@ function before_all
     _purge_configs
     _disable_colors
     set --universal pure_shorten_prompt_current_directory_length 0
+    set --universal pure_truncate_prompt_current_directory_keeps 0
 end
 
 function after_all

--- a/tests/mocks/functions/kubectl.mock.fish
+++ b/tests/mocks/functions/kubectl.mock.fish
@@ -4,11 +4,11 @@ function kubectl \
     topcommand \
     subcommand
 
-    if test $topcommand = config
+    if test "$topcommand" = config
         if test $subcommand = current-context
             echo my-context
         end
-        if test $subcommand = view
+        if test "$subcommand" = view
             echo my-namespace
         end
     else

--- a/tools/installer.fish
+++ b/tools/installer.fish
@@ -34,7 +34,7 @@ function pure_fetch_source
     set --local package "https://github.com/pure-fish/pure/archive/master.tar.gz"
     mkdir -p $PURE_INSTALL_DIR
 
-    command curl --silent --show-error --location "$package" | command tar -xzf- -C $PURE_INSTALL_DIR --strip-components=1; or begin;
+    command curl --silent --show-error --location "$package" | command tar -xzf- -C $PURE_INSTALL_DIR --strip-components=1; or begin
         printf "%sError: fetching Pure sources failed%s" "$color_error" "$color_normal"
         return 1
     end
@@ -46,7 +46,8 @@ function pure_backup_existing_theme
     set --local backup_prompt $old_prompt.ignore
 
     if test -f "$old_prompt"
-        mv "$old_prompt" "$backup_prompt"; pure_exit_symbol $status
+        mv "$old_prompt" "$backup_prompt"
+        pure_exit_symbol $status
         printf "\tPrevious config saved to: %s%s%s." "$color_white" "$backup_prompt" "$color_normal"
     end
 end
@@ -55,9 +56,9 @@ function pure_enable_autoloading
     printf "\tEnabling autoloading for pure's functions on shell init"
     touch "$FISH_CONFIG_DIR/config.fish"
     if not grep -q "pure.fish" $FISH_CONFIG_DIR/config.fish
-        echo "# THEME PURE #" >> $FISH_CONFIG_DIR/config.fish
-        echo "set fish_function_path $PURE_INSTALL_DIR/functions/" '$fish_function_path' >> $FISH_CONFIG_DIR/config.fish
-        echo "source $PURE_INSTALL_DIR/conf.d/pure.fish" >> $FISH_CONFIG_DIR/config.fish
+        echo "# THEME PURE #" >>$FISH_CONFIG_DIR/config.fish
+        echo "set fish_function_path $PURE_INSTALL_DIR/functions/" '$fish_function_path' >>$FISH_CONFIG_DIR/config.fish
+        echo "source $PURE_INSTALL_DIR/conf.d/pure.fish" >>$FISH_CONFIG_DIR/config.fish
     end
 end
 
@@ -97,7 +98,7 @@ function pure_error
 end
 
 function pure_exit_symbol
-    if test $argv[1] -eq 0
+    if test "$argv[1]" -eq 0
         pure_success
     else
         pure_error
@@ -108,11 +109,18 @@ function install_pure
     printf "Installing Pure theme\n"
     pure_set_fish_config_path $argv
     pure_set_pure_install_path $argv
-    pure_scaffold_fish_directories; pure_exit_symbol $status
-    pure_fetch_source; pure_exit_symbol $status
-    pure_backup_existing_theme; pure_exit_symbol $status
-    pure_enable_autoloading; pure_exit_symbol $status
-    pure_symlinks_assets; pure_exit_symbol $status
-    pure_enable_theme; pure_exit_symbol $status
-    pure_clean_after_install; pure_exit_symbol $status
+    pure_scaffold_fish_directories
+    pure_exit_symbol $status
+    pure_fetch_source
+    pure_exit_symbol $status
+    pure_backup_existing_theme
+    pure_exit_symbol $status
+    pure_enable_autoloading
+    pure_exit_symbol $status
+    pure_symlinks_assets
+    pure_exit_symbol $status
+    pure_enable_theme
+    pure_exit_symbol $status
+    pure_clean_after_install
+    pure_exit_symbol $status
 end


### PR DESCRIPTION
**related:** fixes #336

## How to test pre-release?

> :skull_and_crossbones: Feature **can** be unstable and break your prompt!

```shell
fisher install pure-fish/pure@feat/truncate-directory-path # branch name
set --universal pure_enable_foo_feature true
```

## First contribution?

Check the [:+1: Contribute][contribute] section and the [contributing guide][contributing].

## Specs

### New config in `conf.d/pure.fish`

```fish
set --universal pure_truncate_prompt_current_directory_keeps 2
set --universal pure_truncate_window_title_current_directory_keeps 2
```
<!-- remove if necessary -->

### Documentation

#### Usage

```shell
❯ set --universal pure_truncate_prompt_current_directory_keeps 2
❯ set --universal pure_truncate_window_title_current_directory_keeps 2
```

## Acceptance Checks

* [x] documentation is up-to-date:
  * [x] [features list][features] ;
  * [ ] ~[Prompt Symbol][symbol] ;~
  * [x] [🔌 Features' Flags][feature-flag] ;
* [x] feature flag is present in `conf.d/pure.fish` ;
* ~[ ] symbol is present in `conf.d/pure.fish` ;~
* [ ] **tests are passing (I can help you :hugs: ):** :red_circle: 
  * [ ] config are tested (cf. [tests/_pure.test.fish][config-test]) ;
  * [ ] feature is covered ;
* [x] customization is available ;
* [] feature is implemented.

[config-test]: tests/_pure.test.fish
[contribute]: /pure-fish/pure/#1-contribute
[contributing]: CONTRIBUTING.md
[feature-flag]: /pure-fish/pure/#-features-flags
[symbol]: /pure-fish/pure/#prompt-symbol
[features]: /pure-fish/pure/#features

