### PR TITLE
ci: Pass tests under macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Fish
-        run: brew install fish
+        run: brew install fish@3.3.1
       - name: Install Fisher > Fishtape > Pure
         run: curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher jorgebucaran/fishtape ./
         shell: fish {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,19 +56,19 @@ jobs:
       - run: docker --version
       - run: make test-pure-on-nix FISH_VERSION=${{ matrix.version.fish }}
 
-  # test-macos:
-  #   name: Test on fish on MacOS
-  #   runs-on: macos-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Install Fish
-  #       run: brew install fish
-  #     - name: Install Fisher > Fishtape > Pure
-  #       run: curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher jorgebucaran/fishtape ./
-  #       shell: fish {0}
-  #     - name: Test Pure
-  #       run: fishtape tests/*.test.fish
-  #       shell: fish {0}
+  test-macos:
+    name: Test on fish on MacOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Fish
+        run: brew install fish
+      - name: Install Fisher > Fishtape > Pure
+        run: curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher jorgebucaran/fishtape ./
+        shell: fish {0}
+      - name: Test Pure
+        run: fishtape tests/*.test.fish
+        shell: fish {0}
 
   bump-version: # Bump when on master
     needs: [test-container]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Fish
-        run: brew install fish@3.3.1
+        run: brew install fish
       - name: Install Fisher > Fishtape > Pure
         run: curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher jorgebucaran/fishtape ./
         shell: fish {0}

--- a/functions/_pure_check_for_new_release.fish
+++ b/functions/_pure_check_for_new_release.fish
@@ -20,5 +20,5 @@ function pure_get_latest_release_version \
     curl \
         --silent \
         "https://api.github.com/repos/$user_repo/releases/latest" \
-    | string match --regex  '"tag_name": "\K.*?(?=")'
+        | string match --regex '"tag_name": "\K.*?(?=")'
 end

--- a/tests/_pure_check_for_new_release.test.fish
+++ b/tests/_pure_check_for_new_release.test.fish
@@ -20,6 +20,7 @@ before_each
 before_each
 @test "_pure_check_for_new_release: nothing when same as latest" (
     set --universal pure_check_for_new_release true
+    set --erase pure_version
     set --universal pure_version 0.0.1
     function curl; echo '"tag_name": "v0.0.1",'; end # mock
 
@@ -29,6 +30,7 @@ before_each
 before_each
 @test "_pure_check_for_new_release: show fisher command to install when enable" (
     set --universal pure_check_for_new_release true
+    set --erase pure_version
     set --universal pure_version 0.0.1
     function curl; echo '"tag_name": "v9.9.9",'; end # mock
 

--- a/tests/_pure_is_inside_container.test.fish
+++ b/tests/_pure_is_inside_container.test.fish
@@ -54,11 +54,15 @@ end
 ) = once
 
 cleanup_spy
-@test "_pure_is_inside_container: true for Github Action" (
+@test "_pure_is_inside_container: false for Github Action" (
     set --universal pure_enable_container_detection true
 
     _pure_is_inside_container
-) $status -eq $SUCCESS
+) $status -eq (if test (uname) = Darwin
+    echo $FAILURE
+else
+    echo $SUCCESS
+end)
 
 @test "_pure_is_inside_container: detect with $container variable" (
     set --universal pure_enable_container_detection true

--- a/tests/_pure_is_inside_container.test.fish
+++ b/tests/_pure_is_inside_container.test.fish
@@ -53,16 +53,25 @@ end
     echo $called
 ) = once
 
-cleanup_spy
-@test "_pure_is_inside_container: false for Github Action" (
-    set --universal pure_enable_container_detection true
+if test (uname -s) != Darwin
+    cleanup_spy
+    @test "_pure_is_inside_container: true for Github Action on Ubuntu" (
+        set --universal pure_enable_container_detection true
 
-    _pure_is_inside_container
-) $status -eq (if test (uname) = Darwin
-    echo $FAILURE
-else
-    echo $SUCCESS
-end)
+        _pure_is_inside_container
+    ) $status -eq $SUCCESS
+    end
+end
+
+if test (uname -s) = Darwin
+    cleanup_spy
+    @test "_pure_is_inside_container: false for Github Action on MacOS" (
+        set --universal pure_enable_container_detection true
+
+	    _pure_is_inside_container
+    ) $status -eq $FAILURE
+    end
+end
 
 @test "_pure_is_inside_container: detect with $container variable" (
     set --universal pure_enable_container_detection true

--- a/tests/_pure_is_inside_container.test.fish
+++ b/tests/_pure_is_inside_container.test.fish
@@ -60,7 +60,6 @@ if test (uname -s) != Darwin
 
         _pure_is_inside_container
     ) $status -eq $SUCCESS
-    end
 end
 
 if test (uname -s) = Darwin
@@ -68,9 +67,8 @@ if test (uname -s) = Darwin
     @test "_pure_is_inside_container: false for Github Action on MacOS" (
         set --universal pure_enable_container_detection true
 
-	    _pure_is_inside_container
+        _pure_is_inside_container
     ) $status -eq $FAILURE
-    end
 end
 
 @test "_pure_is_inside_container: detect with $container variable" (

--- a/tests/_pure_print_prompt_rows.test.fish
+++ b/tests/_pure_print_prompt_rows.test.fish
@@ -19,14 +19,14 @@ before_each
 @test "_pure_print_prompt_rows: end with newline by default" (
     set --universal pure_enable_single_line_prompt false
 
-    _pure_print_prompt_rows | wc -l
+    _pure_print_prompt_rows | wc -l | tr -d ' '
 ) = $IS_PRESENT
 
 before_each
 @test "_pure_print_prompt_rows: end WITHOUT newline when compact-prompt is enable" (
     set --universal pure_enable_single_line_prompt true
 
-    _pure_print_prompt_rows | wc -l
+    _pure_print_prompt_rows | wc -l | tr -d ' '
 ) = $NONE
 
 

--- a/tests/_pure_prompt_new_line.test.fish
+++ b/tests/_pure_prompt_new_line.test.fish
@@ -22,21 +22,21 @@ end
     set --universal pure_enable_single_line_prompt false
     set _pure_fresh_session false
 
-    _pure_prompt_new_line | wc -l
+    _pure_prompt_new_line | wc -l | tr -d ' '
 ) -eq $IS_PRESENT
 
 @test "_pure_prompt_new_line: print prompt without newline for new session" (
     set --universal pure_enable_single_line_prompt false
     set _pure_fresh_session true
 
-    _pure_prompt_new_line | wc -l
+    _pure_prompt_new_line | wc -l | tr -d ' '
 ) = $NONE
 
 @test "_pure_prompt_new_line: print prompt without newline when single line prompt is enabled" (
     set _pure_fresh_session false
     set --universal pure_enable_single_line_prompt true
 
-    _pure_prompt_new_line | wc -l
+    _pure_prompt_new_line | wc -l | tr -d ' '
 ) = $NONE
 
 before_each

--- a/tests/fish_prompt.test.fish
+++ b/tests/fish_prompt.test.fish
@@ -61,13 +61,13 @@ before_all
 
 @test "fish_prompt: use 2-lines prompt by default" (
     set --universal pure_enable_single_line_prompt false
-    fish_prompt | wc -l
+    fish_prompt | wc -l | tr -d ' '
 ) = 2
 
 @test "fish_prompt: use 1-line compact-prompt" (
     set --universal pure_enable_single_line_prompt true
 
-    fish_prompt | wc -l
+    fish_prompt | wc -l | tr -d ' '
 ) = 1
 
 after_all


### PR DESCRIPTION
**Related**: Fixes #294

## Description

This fixes the tests so macOS CI passes. There were two main issues:
- [osx wc printing unexpected spaces](https://stackoverflow.com/questions/30927590/wc-on-osx-return-includes-spaces)
  - trimmed the spaces with tr
- `set -U` not working on macOS (currently fish version 3.7)
  - to fix this, erasing the variable before setting it somehow made it work

## First contribution?

Check the [:+1: Contribute][contribute] section and the [contributing guide][contributing].

## Acceptance Checks

* [ ] documentation is up-to-date:
  * [ ] [features list][features] ;
  * [ ] [Prompt Symbol][symbol] ;
  * [ ] [🔌 Features' Flags][feature-flag] ;
* [ ] feature flag is present in `conf.d/pure.fish` ;
* [ ] symbol is present in `conf.d/pure.fish` ;
* [x] tests are passing (I can help you :hugs: ):
  * [ ] config are tested (cf. [tests/_pure.test.fish][config-test]) ;
  * [ ] feature is covered ;
* [ ] customization is available ;
* [x] feature is implemented.

[config-test]: tests/_pure.test.fish
[contribute]: /pure-fish/pure/#1-contribute
[contributing]: CONTRIBUTING.md
[feature-flag]: /pure-fish/pure/#-features-flags
[symbol]: /pure-fish/pure/#prompt-symbol
[features]: /pure-fish/pure/#features
