### PR TITLE
feat: aws profile prompt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,6 @@ jobs:
 
   bump-version: # Bump when on master
     needs: [test-container]
-    if: contains(github.ref, 'master')
+    if: contains(github.ref, 'master') && github.repository == 'pure-fish/pure'
     uses: ./.github/workflows/bump-version.yml
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Fully **customizable** (colors, symbols and features):
 * [Display _username_ and _hostname_ when in an `SSH` session 🛠][ssh-session] ;
 * [Display command _duration_ when longer than `5` seconds 🛠][time-duration] ;
 * [Display `Python` _virtualenv_ when activated 🏴🛠][python-virtualenv] ;
+* [Display `AWS` profile when set 🏴🛠][aws-profile] ;
 * [Display `VI` mode and custom symbol for non-insert mode 🏴🛠][vi-mode] ;
 * [Display `kubernetes` context and namespace 🏴🛠][kubernetes] ;
 * [Detect when running in a container (e.g. `docker`, `podman`, `LXC`/`LXD`) 🏴🛠][container-detection-docker]
@@ -124,6 +125,7 @@ Checkout our [Contribution Guide][contribution] to get familiar with our convent
 [nix-os]: https://pure-fish.github.io/pure/#nix-os
 [prompt-symbol]: https://pure-fish.github.io/pure/#prompt-symbol
 [python-virtualenv]: https://pure-fish.github.io/pure/#python-virtualenv
+[aws-profile]: https://pure-fish.github.io/pure/#aws-profile
 [separate-error-symbol]: https://pure-fish.github.io/pure/#separate-error-symbol
 [single-line-prompt]: https://pure-fish.github.io/pure/#single-line-prompt
 [ssh-session]: https://pure-fish.github.io/pure/#ssh-session

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -60,6 +60,8 @@ _pure_set_default pure_symbol_virtualenv_prefix "" # 🐍
 _pure_set_default pure_color_virtualenv pure_color_mute
 
 # AWS profile name
+_pure_set_default pure_enable_aws_profile true
+_pure_set_default pure_symbol_aws_profile_prefix "" # ☁️
 _pure_set_default pure_color_aws_profile pure_color_warning
 
 # Print current working directory at the beginning of prompt

--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -59,6 +59,9 @@ _pure_set_default pure_enable_virtualenv true
 _pure_set_default pure_symbol_virtualenv_prefix "" # 🐍
 _pure_set_default pure_color_virtualenv pure_color_mute
 
+# AWS profile name
+_pure_set_default pure_color_aws_profile pure_color_warning
+
 # Print current working directory at the beginning of prompt
 # true (default):   current directory, git, user@hostname (ssh-only), command duration
 # false:            user@hostname (ssh-only), current directory, git, command duration

--- a/docs/components/features-list.md
+++ b/docs/components/features-list.md
@@ -82,6 +82,13 @@
 | **`pure_enable_virtualenv`**        | `true`  | Show virtual env name (based on `VIRTUAL_ENV` or `CONDA_DEFAULT_ENV`).       |
 | **`pure_symbol_virtualenv_prefix`** |         | Prefix when a Python virtual env is activated (default: [undefined][to-set]) |
 
+### AWS Profile
+
+| Option                              | Default | Description                                                                  |
+| :---------------------------------- | :------ | :--------------------------------------------------------------------------- |
+| **`pure_enable_aws_profile`**        | `true`  | Show AWS profile name (based on `AWS_VAULT` or `AWS_PROFILE`).       |
+| **`pure_symbol_aws_profile_prefix`** |         | Prefix when a AWS profile is activated (default: [undefined][to-set]) |
+
 ### Separate Error Symbol
 
 | Option                              | Default | Description                                                         |

--- a/docs/components/features-overview.md
+++ b/docs/components/features-overview.md
@@ -13,6 +13,7 @@ Fully **customizable** (colors, symbols and features):
 * [Display _username_ and _hostname_ when in an `SSH` session 🛠][ssh-session] ;
 * [Display command _duration_ when longer than `5` seconds 🛠][time-duration] ;
 * [Display `Python` _virtualenv_ when activated 🏴🛠][python-virtualenv] ;
+* [Display `AWS`  profile when set 🏴🛠][aws-profile] ;
 * [Display `VI` mode and custom symbol for non-insert mode 🏴🛠][vi-mode] ;
 * [Display `kubernetes` context and namespace 🏴🛠][kubernetes] ;
 * [Detect when running in a container (e.g. `docker`, `podman`, `LXC`/`LXD`) 🏴🛠][container-detection-docker]
@@ -45,6 +46,7 @@ Fully **customizable** (colors, symbols and features):
 [nix-os]: #nix-os
 [prompt-symbol]: #prompt-symbol
 [python-virtualenv]: #python-virtualenv
+[aws-profile]: #aws-profile
 [separate-error-symbol]: #separate-error-symbol
 [single-line-prompt]: #single-line-prompt
 [ssh-session]: #ssh-session

--- a/docs/components/features-overview.md
+++ b/docs/components/features-overview.md
@@ -13,7 +13,7 @@ Fully **customizable** (colors, symbols and features):
 * [Display _username_ and _hostname_ when in an `SSH` session 🛠][ssh-session] ;
 * [Display command _duration_ when longer than `5` seconds 🛠][time-duration] ;
 * [Display `Python` _virtualenv_ when activated 🏴🛠][python-virtualenv] ;
-* [Display `AWS`  profile when set 🏴🛠][aws-profile] ;
+* [Display `AWS` profile when set 🏴🛠][aws-profile] ;
 * [Display `VI` mode and custom symbol for non-insert mode 🏴🛠][vi-mode] ;
 * [Display `kubernetes` context and namespace 🏴🛠][kubernetes] ;
 * [Detect when running in a container (e.g. `docker`, `podman`, `LXC`/`LXD`) 🏴🛠][container-detection-docker]
@@ -22,7 +22,7 @@ Fully **customizable** (colors, symbols and features):
 * [Show number of running jobs 🏴][jobs] ;
 * [Prefix when `root` 🏴🛠][working-as-root] ;
 * [Display `git` branch name 🏴🛠][git] ;
-  
+
     * Display `*` when `git` repository is _dirty_ ;
     * Display `≡` when `git` repository is _stashed_ ;
     * Display `⇡` when branch is _ahead_ (commits to push) ;

--- a/functions/_pure_prompt.fish
+++ b/functions/_pure_prompt.fish
@@ -5,6 +5,7 @@ function _pure_prompt \
     set --local jobs (_pure_prompt_jobs)
     set --local nixdevshell (_pure_prompt_nixdevshell) # Nix build environment indicator
     set --local virtualenv (_pure_prompt_virtualenv) # Python virtualenv name
+    set --local aws_profile (_pure_prompt_aws_profile) # AWS profile name
     set --local vimode_indicator (_pure_prompt_vimode) # vi-mode indicator
     set --local pure_symbol (_pure_prompt_symbol $exit_code)
     set --local system_time (_pure_prompt_system_time)
@@ -23,6 +24,7 @@ function _pure_prompt \
         $jobs \
         $nixdevshell \
         $virtualenv \
+        $aws_profile \
         $vimode_indicator \
         $pure_symbol \
     )

--- a/functions/_pure_prompt_aws_profile.fish
+++ b/functions/_pure_prompt_aws_profile.fish
@@ -1,0 +1,13 @@
+function _pure_prompt_aws_profile --description "Display AWS profile name"
+    if test -n "$AWS_VAULT"
+        set --local aws_profile "$AWS_VAULT"
+        set --local aws_profile_color (_pure_set_color $pure_color_aws_profile)
+
+        echo "$aws_profile_color$aws_profile"
+    else if test -n "$AWS_PROFILE" -o "$AWS_PROFILE" != default
+        set --local aws_profile "$AWS_PROFILE"
+        set --local aws_profile_color (_pure_set_color $pure_color_aws_profile)
+
+        echo "$aws_profile_color$aws_profile"
+    end
+end

--- a/functions/_pure_prompt_aws_profile.fish
+++ b/functions/_pure_prompt_aws_profile.fish
@@ -1,13 +1,19 @@
 function _pure_prompt_aws_profile --description "Display AWS profile name"
-    if test -n "$AWS_VAULT"
-        set --local aws_profile "$AWS_VAULT"
+
+    if set --query pure_enable_aws_profile;
+        and test "$pure_enable_aws_profile" = true
+
+        set --local aws_profile ''
         set --local aws_profile_color (_pure_set_color $pure_color_aws_profile)
 
-        echo "$aws_profile_color$aws_profile"
-    else if test -n "$AWS_PROFILE" -o "$AWS_PROFILE" != default
-        set --local aws_profile "$AWS_PROFILE"
-        set --local aws_profile_color (_pure_set_color $pure_color_aws_profile)
+        if test -n "$AWS_VAULT"
+            set aws_profile "$AWS_VAULT"
+        else if test -n "$AWS_PROFILE" -o "$AWS_PROFILE" != default
+            set aws_profile "$AWS_PROFILE"
+        end
 
-        echo "$aws_profile_color$aws_profile"
+        if test -n $aws_profile
+            echo "$pure_symbol_aws_profile_prefix$aws_profile_color$aws_profile"
+        end
     end
 end

--- a/tests/_pure.test.fish
+++ b/tests/_pure.test.fish
@@ -237,6 +237,24 @@ before_all
     echo $pure_color_virtualenv
 ) = pure_color_mute
 
+@test "configure: pure_enable_aws_profile" (
+    set --erase pure_enable_aws_profile
+    source (status dirname)/../conf.d/pure.fish
+    echo $pure_enable_aws_profile
+) = true
+
+@test "configure: pure_symbol_aws_profile_prefix" (
+    set --erase pure_symbol_aws_profile_prefix
+    source (status dirname)/../conf.d/pure.fish
+    echo $pure_symbol_aws_profile_prefix
+) = $EMPTY
+
+@test "configure: pure_color_aws_profile" (
+    set --erase pure_color_aws_profile
+    source (status dirname)/../conf.d/pure.fish
+    echo $pure_color_aws_profile
+) = pure_color_warning
+
 @test "configure: pure_begin_prompt_with_current_directory" (
     set --erase pure_begin_prompt_with_current_directory
     source (status dirname)/../conf.d/pure.fish

--- a/tests/_pure_prompt.test.fish
+++ b/tests/_pure_prompt.test.fish
@@ -4,6 +4,7 @@ source (status dirname)/../functions/_pure_prompt.fish
 source (status dirname)/../functions/_pure_prompt_jobs.fish
 source (status dirname)/../functions/_pure_prompt_nixdevshell.fish
 source (status dirname)/../functions/_pure_prompt_virtualenv.fish
+source (status dirname)/../functions/_pure_prompt_aws_profile.fish
 source (status dirname)/../functions/_pure_prompt_vimode.fish
 source (status dirname)/../functions/_pure_prompt_symbol.fish
 source (status dirname)/../functions/_pure_get_prompt_symbol.fish

--- a/tests/_pure_prompt_aws_profile.test.fish
+++ b/tests/_pure_prompt_aws_profile.test.fish
@@ -1,0 +1,56 @@
+source (status dirname)/fixtures/constants.fish
+source (status dirname)/../functions/_pure_set_default.fish
+source (status dirname)/../functions/_pure_prompt_aws_profile.fish
+@echo (_print_filename (status filename))
+
+function before_each
+    _purge_configs
+    _disable_colors # we use mocks so cleaning them must happen before
+
+    set --erase AWS_PROFILE
+    set --erase AWS_VAULT
+end
+
+before_each
+@test "_pure_prompt_aws_profile: ensure default behaviour has no error" (
+    source (status dirname)/../conf.d/pure.fish
+
+    _pure_prompt_aws_profile
+) $status -eq $SUCCESS
+
+
+before_each
+@test "_pure_prompt_aws_profile: ensure default behaviour print nothing when no AWS variables" (
+    source (status dirname)/../conf.d/pure.fish
+
+    echo (_pure_prompt_aws_profile)
+) = $EMPTY
+
+before_each
+@test "_pure_prompt_aws_profile: print AWS_VAULT when present" (
+    set --universal pure_enable_aws_profile true
+    set --universal pure_symbol_aws_profile_prefix "🅰"
+    set --global AWS_VAULT my-vault
+
+    _pure_prompt_aws_profile
+) = '🅰my-vault'
+
+before_each
+@test "_pure_prompt_aws_profile: print AWS_PROFILE when present" (
+    set --universal pure_enable_aws_profile true
+    set --universal pure_symbol_aws_profile_prefix "🅰"
+    set --global AWS_PROFILE my-profile
+
+    _pure_prompt_aws_profile
+) = '🅰my-profile'
+
+
+before_each
+@test "_pure_prompt_aws_profile: print only AWS_VAULT when vault and profile are present" (
+    set --universal pure_enable_aws_profile true
+    set --universal pure_symbol_aws_profile_prefix "🅰"
+    set --global AWS_VAULT my-vault
+    set --global AWS_PROFILE my-profile
+
+    _pure_prompt_aws_profile
+) = '🅰my-vault'


### PR DESCRIPTION
related: supersed #346 

Adds the currently active aws profile to prompt.

## How to test pre-release?

> :skull_and_crossbones: Feature **can** be unstable and break your prompt!

```shell
fisher install pure-fish/pure@feat/foo_feature # branch name
set --universal pure_enable_foo_feature true
```

## First contribution?

Check the [:+1: contributing guide][contributing] for code and naming conventions.

## Specs

### New config in `conf.d/pure.fish`

```fish
_pure_set_default pure_enable_aws_profile true
_pure_set_default pure_symbol_aws_profile "🤯"
```
<!-- remove if necessary -->

### Documentation

#### Usage

```shell
❯ set --universal pure_enable_aws_profile true
```

## Acceptance Checks

* [x] Documentation is up-to-date:
  * [x] Add entry in _feature list_ of [README.md][README] ;
  * [x] Add entry in _features' overview_ in [docs/][features-overview]  ;
  * [x] Add section in [feature list][features-list] to document
    * [x] Features' flag ;
    * [x] Prompt symbol ;
* [x] Default are defined in [`conf.d/pure.fish`][default] for:
  * [x] Feature flag ;
  * [x] Symbol ;
* [x] Tests are passing (I can help you :hugs: ):
  * [x] Config are tested (cf. [tests/_pure.test.fish][config-test]) ;
  * [x] Feature is tested in `tests/feature_name.test.fish` ;
* [x] Customization is available ;
* [x] Feature is implemented.

[default]: /pure-fish/pure/blob/master/conf.d/pure.fish
[config-test]: /pure-fish/pure/blob/master/tests/_pure.test.fish
[contributing]: /pure-fish/pure/blob/master/CONTRIBUTING.md
[features-overview]: /pure-fish/pure/blob/master/docs/components/features-overview.md
[README]: /pure-fish/pure/blob/master/README.md
[features-list]: /pure-fish/pure/blob/master/docs/components/features-list.md
