### PR TITLE
fix: source _pure_prompt_new_line event handler instead of relying on autoloading

### DIFF
--- a/conf.d/_pure_init.fish
+++ b/conf.d/_pure_init.fish
@@ -4,8 +4,8 @@ set --global --export VIRTUAL_ENV_DISABLE_PROMPT 1
 # Whether or not is a fresh session
 set --global _pure_fresh_session true
 
-# Register `_pure_prompt_new_line` as an event handler fot `fish_prompt`
-functions --query _pure_prompt_new_line
+# Register `_pure_prompt_new_line` as an event handler for `fish_prompt`
+source $__fish_config_dir/functions/_pure_prompt_new_line.fish
 
 function _pure_uninstall --on-event pure_uninstall
     rm -f $__fish_config_dir/conf.d/pure.fish


### PR DESCRIPTION
**related:** fixes #356 

From the doc: https://fishshell.com/docs/current/language.html#event
> Please note that event handlers only become active when a function is loaded,
> which means you need to otherwise source or execute a function instead of
> relying on autoloading.

---

TODO
* [ ] Fix tests

---

## How to test pre-release?

> :skull_and_crossbones: Feature **can** be unstable and break your prompt!

```shell
fisher install pure-fish/pure@fix/no-line-spacing-between-prompts-356 # branch name
```

## Specs

### Documentation

Event handlers aren't autoloaded, so we need to force loading of the `_pure_prompt_new_line` handler in the init process.

## Acceptance Checks

* [ ] Documentation is up-to-date:
  * [ ] Add entry in _feature list_ of [README.md][README] ;
  * [ ] Add entry in _features' overview_ in [docs/][features-overview]  ;
  * [ ] Add section in [feature list][features-list] to document
    * [ ] Features' flag ;
    * [ ] Prompt symbol ;
* [ ] Default are defined in [`conf.d/pure.fish`][default] for:
  * [ ] Feature flag ;
  * [ ] Symbol ;
* [ ] Tests are passing (I can help you :hugs: ):
  * [ ] Config are tested (cf. [tests/_pure.test.fish][config-test]) ;
  * [ ] Feature is tested in `tests/feature_name.test.fish` ;
* [ ] Customization is available ;
* [ ] Feature is implemented.

[default]: /pure-fish/pure/blob/master/conf.d/pure.fish
[config-test]: /pure-fish/pure/blob/master/tests/_pure.test.fish
[contributing]: /pure-fish/pure/blob/master/CONTRIBUTING.md
[features-overview]: /pure-fish/pure/blob/master/docs/components/features-overview.md
[README]: /pure-fish/pure/blob/master/README.md
[features-list]: /pure-fish/pure/blob/master/docs/components/features-list.md