### PR TITLE
ci: drop 3.6.3 and 3.7.0 in favour of 3.7.1 and 4.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
       matrix:
         version: [
             { fish: 3.3.1, alpine: 3.15 }, # for Ubuntu 22.04 LTS
-            { fish: 3.6.3, alpine: 3.19 },
-            { fish: 3.7.0, alpine: 'edge' },
+            { fish: 3.7.1, alpine: 3.21 },
+            { fish: 4.0.2, alpine: "edge" },
             # { fish: 9.9.9, alpine: 'edge' },
           ]
     steps:

--- a/.github/workflows/nixos.yml
+++ b/.github/workflows/nixos.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         version: [
-            { fish: 3.7.0 }, # https://search.nixos.org/packages?show=fish&type=packages&query=fish
+            { fish: 'latest' }, # https://search.nixos.org/packages?show=fish&type=packages&query=fish
           ]
     steps:
       - name: Checkout repo


### PR DESCRIPTION
https://github.com/pure-fish/docker-fish/blob/main/.github/workflows/build-images.yml
