### PR TITLE
fix(vscode): prevent vscode from adding extra line

### DIFF
--- a/conf.d/pure.fish
+++ b/conf.d/pure.fish
@@ -1,4 +1,4 @@
-set --global pure_version 4.11.3 # For bug report and tag-after-merge workflow
+set --global pure_version 4.11.3-341 # For bug report and tag-after-merge workflow
 
 # Base colors
 _pure_set_default pure_color_primary blue

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -5,7 +5,7 @@ function fish_prompt
     _pure_print_prompt_rows # manage default vs. compact prompt
     _pure_place_iterm2_prompt_mark # place iTerm shell integration mark
     echo -e -n (_pure_prompt $exit_code) # print prompt
-    echo -e (_pure_prompt_ending) # reset colors and end prompt
+    echo -e -n (_pure_prompt_ending) # reset colors and end prompt
 
     set _pure_fresh_session false
 end

--- a/tests/fish_prompt.test.fish
+++ b/tests/fish_prompt.test.fish
@@ -41,7 +41,7 @@ before_all
     set --universal pure_enable_single_line_prompt true
 
     fish_prompt | string collect --no-trim-newlines
-) = '/path/ git duration ❯]'\n
+) = '/path/ git duration ❯]'
 
 
 @test "fish_prompt: change with exit status" (
@@ -61,13 +61,13 @@ before_all
 
 @test "fish_prompt: use 2-lines prompt by default" (
     set --universal pure_enable_single_line_prompt false
-    fish_prompt | wc -l | tr -d ' '
-) = 2
+    fish_prompt | wc -l 
+) = 1 # see https://github.com/pure-fish/pure/pull/380
 
 @test "fish_prompt: use 1-line compact-prompt" (
     set --universal pure_enable_single_line_prompt true
 
-    fish_prompt | wc -l | tr -d ' '
-) = 1
+    fish_prompt | wc -l 
+) = 0 # see https://github.com/pure-fish/pure/pull/380
 
 after_all


### PR DESCRIPTION
Thanks to @wyw message
https://github.com/microsoft/vscode/issues/187185#issuecomment-2694449635

## Test

```
fisher install pure-fish/pure@fix/prompt-contains-newline-in-vscode-terminal-341
```

* [ ] check `terminal.integrated.shellIntegration.enabled`
* [ ] Kill terminal in VSCode
* [ ] re-open terminal in vscode

fixes #341 #379
